### PR TITLE
LOG_LEVEL added to control log output

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,9 +19,11 @@ func main() {
 	if _logLevel := os.Getenv("LOG_LEVEL"); _logLevel != "" {
 		logLevel, err := logrus.ParseLevel(_logLevel)
 
-		if err == nil {
-			log.SetLogLevel(logLevel)
+		if err != nil {
+			log.Fatal(err)
 		}
+
+		log.SetLogLevel(logLevel)
 	}
 
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/codeamp/circuit/cmd"
 	_ "github.com/codeamp/circuit/plugins/codeamp"
 	_ "github.com/codeamp/circuit/plugins/dockerbuilder"
@@ -9,8 +11,18 @@ import (
 	_ "github.com/codeamp/circuit/plugins/heartbeat"
 	_ "github.com/codeamp/circuit/plugins/kubernetes"
 	_ "github.com/codeamp/circuit/plugins/route53"
+	log "github.com/codeamp/logger"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	if _logLevel := os.Getenv("LOG_LEVEL"); _logLevel != "" {
+		logLevel, err := logrus.ParseLevel(_logLevel)
+
+		if err == nil {
+			log.SetLogLevel(logLevel)
+		}
+	}
+
 	cmd.Execute()
 }


### PR DESCRIPTION
LOG_LEVEL env var now controls the level of log output from the internal logger.
We still need to adjust docker-compose.yml to provide LOG_LEVEL if we want to have debug statements in the build.