### PR TITLE
Moved log level setting to be in line with other viper configurations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -64,7 +64,6 @@ func initConfig() {
 			log.Fatal(err)
 		}
 
-		log.Info("Log Level: ", logLevel)
 		log.SetLogLevel(logLevel)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	log "github.com/codeamp/logger"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,5 +55,16 @@ func initConfig() {
 		log.InfoWithFields("config loaded", log.Fields{
 			"config": viper.ConfigFileUsed(),
 		})
+	}
+
+	if _logLevel := viper.GetString("LOG_LEVEL"); _logLevel != "" {
+		logLevel, err := logrus.ParseLevel(_logLevel)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.Info("Log Level: ", logLevel)
+		log.SetLogLevel(logLevel)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/codeamp/circuit/cmd"
 	_ "github.com/codeamp/circuit/plugins/codeamp"
 	_ "github.com/codeamp/circuit/plugins/dockerbuilder"
@@ -11,20 +9,8 @@ import (
 	_ "github.com/codeamp/circuit/plugins/heartbeat"
 	_ "github.com/codeamp/circuit/plugins/kubernetes"
 	_ "github.com/codeamp/circuit/plugins/route53"
-	log "github.com/codeamp/logger"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	if _logLevel := os.Getenv("LOG_LEVEL"); _logLevel != "" {
-		logLevel, err := logrus.ParseLevel(_logLevel)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.SetLogLevel(logLevel)
-	}
-
 	cmd.Execute()
 }


### PR DESCRIPTION
Log level setting on initial commit was out of place with other configurations.
Moved to where the configuration is loaded in the first place and now uses viper instead of os.Getenv.

Log level can be set with 'log_level' in config file or 'CODEAMP_LOG_LEVEL' in an env as currently configured.