### PR TITLE
Events data removed from payload

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
   branch = "refactor/events-have-event-info"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "6aef95d399b5c6298fe5f0a8fe17611599d1daa4"
+  revision = "805ee56a440c34f281908674f7e43eea7b007c01"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
   branch = "refactor/events-have-event-info"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "c776cb6aa9e1c5d5f2fccfd990f679fe5327b1d2"
+  revision = "4d5808a4f10f78a88bc992a7abb2f09297049156"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,10 +104,10 @@
   revision = "3af44e5f22c2a3ace490347b8f65e51db8d28126"
 
 [[projects]]
-  branch = "refactor/events-have-event-info"
+  branch = "master"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "9687078869692b74dac449b752f681ee0c673200"
+  revision = "cb56a5a2ec001b68022ad1072f001cb089920495"
 
 [[projects]]
   branch = "master"
@@ -823,6 +823,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "673a17b20c2bfc2a03f1fd2ce9dc5288bdc5b5ff340ecade938b23b93077915e"
+  inputs-digest = "b4d0de6698558ea2ef0a3beef70c14bf3ae0735372dae1daf6768dfce013990b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -104,10 +104,10 @@
   revision = "3af44e5f22c2a3ace490347b8f65e51db8d28126"
 
 [[projects]]
-  branch = "master"
+  branch = "refactor/events-have-event-info"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "34f9ff3b17c118401b6ba140ae4c261cac1b2dcd"
+  revision = "c776cb6aa9e1c5d5f2fccfd990f679fe5327b1d2"
 
 [[projects]]
   branch = "master"
@@ -823,6 +823,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4acf39d3c174a6f2ec17f0e760f12719675a2e5d01a074f4fa59c9fd305115ef"
+  inputs-digest = "73d5d88e989e3532e219cf27e0942bee9739e9500a5808619e0a15f592b65cca"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
   branch = "refactor/events-have-event-info"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "805ee56a440c34f281908674f7e43eea7b007c01"
+  revision = "9687078869692b74dac449b752f681ee0c673200"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
   branch = "refactor/events-have-event-info"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "4d5808a4f10f78a88bc992a7abb2f09297049156"
+  revision = "6aef95d399b5c6298fe5f0a8fe17611599d1daa4"
 
 [[projects]]
   branch = "master"
@@ -823,6 +823,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "73d5d88e989e3532e219cf27e0942bee9739e9500a5808619e0a15f592b65cca"
+  inputs-digest = "673a17b20c2bfc2a03f1fd2ce9dc5288bdc5b5ff340ecade938b23b93077915e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@
   name = "github.com/codeamp/logger"
 
 [[constraint]]
-  branch = "refactor/events-have-event-info"
+  branch = "master"
   name = "github.com/codeamp/transistor"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -25,7 +25,7 @@
   name = "github.com/codeamp/logger"
 
 [[constraint]]
-  branch = "master"
+  branch = "refactor/events-have-event-info"
   name = "github.com/codeamp/transistor"
 
 [[constraint]]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Circuit [![CircleCI](https://circleci.com/gh/codeamp/circuit.svg?style=svg)](https://circleci.com/gh/codeamp/circuit) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) [![Coverage Status](https://coveralls.io/repos/github/codeamp/circuit/badge.svg?branch=master)](https://coveralls.io/github/codeamp/circuit?branch=master) [![Go Report Card](https://goreportcard.com/badge/codeamp/circuit)](https://goreportcard.com/report/codeamp/circuit) [![codebeat badge](https://codebeat.co/badges/b977a7e7-1e94-43e1-9e58-463cff99add3)](https://codebeat.co/projects/github-com-codeamp-circuit-master)
 This is the API layer of the overall Codeamp project. It is built with Golang, GraphQL, GORM and Socket-IO.
 
+[![CircleCI](https://circleci.com/gh/codeamp/circuit/tree/master.svg?style=svg)](https://circleci.com/gh/codeamp/circuit/tree/master)
 
 ## Installation
 

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -84,7 +84,7 @@ func pluginsCodeampSchemaGraphql() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "plugins/codeamp/schema.graphql", size: 7509, mode: os.FileMode(420), modTime: time.Unix(1525737872, 0)}
+	info := bindataFileInfo{name: "plugins/codeamp/schema.graphql", size: 7509, mode: os.FileMode(420), modTime: time.Unix(1525754909, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -104,7 +104,7 @@ func pluginsCodeampStaticIndexHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "plugins/codeamp/static/index.html", size: 2810, mode: os.FileMode(420), modTime: time.Unix(1510690037, 0)}
+	info := bindataFileInfo{name: "plugins/codeamp/static/index.html", size: 2810, mode: os.FileMode(420), modTime: time.Unix(1519789868, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/main.go
+++ b/main.go
@@ -19,9 +19,11 @@ func main() {
 	if _logLevel := os.Getenv("LOG_LEVEL"); _logLevel != "" {
 		logLevel, err := logrus.ParseLevel(_logLevel)
 
-		if err == nil {
-			log.SetLogLevel(logLevel)
+		if err != nil {
+			log.Fatal(err)
 		}
+
+		log.SetLogLevel(logLevel)
 	}
 
 	cmd.Execute()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	"github.com/codeamp/circuit/cmd"
 	_ "github.com/codeamp/circuit/plugins/codeamp"
 	_ "github.com/codeamp/circuit/plugins/dockerbuilder"
@@ -9,8 +11,18 @@ import (
 	_ "github.com/codeamp/circuit/plugins/heartbeat"
 	_ "github.com/codeamp/circuit/plugins/kubernetes"
 	_ "github.com/codeamp/circuit/plugins/route53"
+	log "github.com/codeamp/logger"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	if _logLevel := os.Getenv("LOG_LEVEL"); _logLevel != "" {
+		logLevel, err := logrus.ParseLevel(_logLevel)
+
+		if err == nil {
+			log.SetLogLevel(logLevel)
+		}
+	}
+
 	cmd.Execute()
 }

--- a/main.go
+++ b/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-
 	"github.com/codeamp/circuit/cmd"
 	_ "github.com/codeamp/circuit/plugins/codeamp"
 	_ "github.com/codeamp/circuit/plugins/dockerbuilder"
@@ -11,20 +9,8 @@ import (
 	_ "github.com/codeamp/circuit/plugins/heartbeat"
 	_ "github.com/codeamp/circuit/plugins/kubernetes"
 	_ "github.com/codeamp/circuit/plugins/route53"
-	log "github.com/codeamp/logger"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	if _logLevel := os.Getenv("LOG_LEVEL"); _logLevel != "" {
-		logLevel, err := logrus.ParseLevel(_logLevel)
-
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		log.SetLogLevel(logLevel)
-	}
-
 	cmd.Execute()
 }

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -32,7 +32,16 @@ import (
 )
 
 func init() {
-	transistor.RegisterPlugin("codeamp", func() transistor.Plugin { return NewCodeAmp() })
+	transistor.RegisterPlugin("codeamp", func() transistor.Plugin {
+		return &CodeAmp{}
+	},
+		plugins.Project{},
+		plugins.HeartBeat{},
+		plugins.GitSync{},
+		plugins.WebsocketMsg{},
+		plugins.ProjectExtension{},
+		plugins.ReleaseExtension{},
+		plugins.Release{})
 }
 
 type CodeAmp struct {
@@ -43,10 +52,6 @@ type CodeAmp struct {
 	DB             *gorm.DB
 	Redis          *redis.Client
 	Resolver       *resolvers.Resolver
-}
-
-func NewCodeAmp() *CodeAmp {
-	return &CodeAmp{}
 }
 
 //Custom server which basically only contains a socketio variable
@@ -165,7 +170,7 @@ func (x *CodeAmp) Stop() {
 
 func (x *CodeAmp) Subscribe() []string {
 	return []string{
-		"gitsync:complete",
+		"gitsync:status",
 		"heartbeat",
 		"websocket",
 		"project",

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -305,41 +305,44 @@ func (x *CodeAmp) WebsocketMsgEventHandler(e transistor.Event) error {
 	return nil
 }
 
-func (x *CodeAmp) ProjectExtensionEventHandler(e transistor.Event) error {
-	payload := e.Payload.(plugins.ProjectExtension)
-	var extension resolvers.ProjectExtension
-	var project resolvers.Project
+func (x *CodeAmp) ProjectEventHandler(e transistor.Event) error {
+	if e.PayloadModel == "plugins.ProjectExtension" {
+		payload := e.Payload.(plugins.ProjectExtension)
+		var extension resolvers.ProjectExtension
+		var project resolvers.Project
 
-	if e.Matches("project:status") {
-		if x.DB.Where("id = ?", payload.ID).Find(&extension).RecordNotFound() {
-			log.InfoWithFields("extension not found", log.Fields{
-				"id": payload.ID,
-			})
-			return fmt.Errorf(fmt.Sprintf("Could not handle ProjectExtension status event because ProjectExtension not found given payload id: %s.", payload.ID))
-		}
-
-		if x.DB.Where("id = ?", extension.ProjectID).Find(&project).RecordNotFound() {
-			log.InfoWithFields("project not found", log.Fields{
-				"id": extension.ProjectID,
-			})
-			return fmt.Errorf(fmt.Sprintf("Could not handle ProjectExtension status event because Project not found given payload id: %s.", extension.ProjectID))
-		}
-
-		if e.State == plugins.GetState("complete") {
-			if len(e.Artifacts) > 0 {
-				marshalledReArtifacts, err := json.Marshal(e.Artifacts)
-				if err != nil {
-					log.Info(err.Error(), log.Fields{})
-				}
-				extension.Artifacts = postgres.Jsonb{marshalledReArtifacts}
+		if e.Matches("project:status") {
+			if x.DB.Where("id = ?", payload.ID).Find(&extension).RecordNotFound() {
+				log.InfoWithFields("extension not found", log.Fields{
+					"id": payload.ID,
+				})
+				return fmt.Errorf(fmt.Sprintf("Could not handle ProjectExtension status event because ProjectExtension not found given payload id: %s.", payload.ID))
 			}
+
+			if x.DB.Where("id = ?", extension.ProjectID).Find(&project).RecordNotFound() {
+				log.InfoWithFields("project not found", log.Fields{
+					"id": extension.ProjectID,
+				})
+				return fmt.Errorf(fmt.Sprintf("Could not handle ProjectExtension status event because Project not found given payload id: %s.", extension.ProjectID))
+			}
+
+			if e.State == plugins.GetState("complete") {
+				if len(e.Artifacts) > 0 {
+					marshalledReArtifacts, err := json.Marshal(e.Artifacts)
+					if err != nil {
+						log.Info(err.Error(), log.Fields{})
+					}
+					extension.Artifacts = postgres.Jsonb{marshalledReArtifacts}
+				}
+			}
+
+			x.DB.Save(&extension)
+
+			event := transistor.NewEvent(plugins.GetEventName("websocket"), plugins.GetAction("status"), extension)
+			event.AddArtifact("event", fmt.Sprintf("projects/%s/%s/extensions", project.Slug, payload.Environment), false)
+			x.Events <- event
 		}
-
-		x.DB.Save(&extension)
-
-		event := transistor.NewEvent(plugins.GetEventName("websocket"), plugins.GetAction("status"), extension)
-		event.AddArtifact("event", fmt.Sprintf("projects/%s/%s/extensions", project.Slug, payload.Environment), false)
-		x.Events <- event
+		return nil
 	}
 
 	return nil
@@ -347,118 +350,121 @@ func (x *CodeAmp) ProjectExtensionEventHandler(e transistor.Event) error {
 
 func (x *CodeAmp) ReleaseEventHandler(e transistor.Event) error {
 	var err error
-	payload := e.Payload.(plugins.Release)
-	release := resolvers.Release{}
-	releaseExtensions := []resolvers.ReleaseExtension{}
 
-	if x.DB.Where("id = ?", payload.ID).First(&release).RecordNotFound() {
-		log.InfoWithFields("release not found", log.Fields{
-			"id": payload.ID,
-		})
-		return fmt.Errorf("release %s not found", payload.ID)
-	}
+	if e.PayloadModel == "plugins.ReleaseExtension" {
+		payload := e.Payload.(plugins.ReleaseExtension)
 
-	if e.Matches("release:create") {
-		x.DB.Where("release_id = ?", release.Model.ID).Find(&releaseExtensions)
+		var releaseExtension resolvers.ReleaseExtension
+		var release resolvers.Release
 
-		for _, releaseExtension := range releaseExtensions {
-			projectExtension := resolvers.ProjectExtension{}
-			if x.DB.Where("id = ?", releaseExtension.ProjectExtensionID).Find(&projectExtension).RecordNotFound() {
-				log.InfoWithFields("project extensions not found", log.Fields{
-					"id": releaseExtension.ProjectExtensionID,
-					"release_extension_id": releaseExtension.Model.ID,
+		if e.Matches("releaseextension:status") {
+			if x.DB.Where("id = ?", payload.Release.ID).Find(&release).RecordNotFound() {
+				log.InfoWithFields("release", log.Fields{
+					"id": payload.Release.ID,
 				})
-				return fmt.Errorf("project extension %s not found", releaseExtension.ProjectExtensionID)
+				return fmt.Errorf("Release %s not found", payload.Release.ID)
 			}
 
-			extension := resolvers.Extension{}
-			if x.DB.Where("id= ?", projectExtension.ExtensionID).Find(&extension).RecordNotFound() {
-				log.InfoWithFields("extension not found", log.Fields{
-					"id": projectExtension.Model.ID,
-					"release_extension_id": releaseExtension.Model.ID,
+			if x.DB.Where("id = ?", payload.ID).Find(&releaseExtension).RecordNotFound() {
+				log.InfoWithFields("release extension not found", log.Fields{
+					"id": payload.ID,
 				})
-				return fmt.Errorf("extension %s not found", projectExtension.ExtensionID)
+				return fmt.Errorf("Release extension %s not found", payload.ID)
 			}
 
-			if plugins.Type(extension.Type) == plugins.GetType("workflow") {
-				// check if the last release extension has the same
-				// ServicesSignature and SecretsSignature. If so,
-				// mark the action as completed before sending the event
-				lastReleaseExtension := resolvers.ReleaseExtension{}
-				artifacts := []transistor.Artifact{}
+			marshalledReArtifacts, err := json.Marshal(e.Artifacts)
+			if err != nil {
+				log.Info(err.Error(), log.Fields{})
+				return err
+			}
 
-				eventAction := plugins.GetAction("create")
+			releaseExtension.Artifacts = postgres.Jsonb{marshalledReArtifacts}
+			x.DB.Save(&releaseExtension)
 
-				// check if can cache workflows
-				if !release.ForceRebuild && !x.DB.Where("project_extension_id = ? and services_signature = ? and secrets_signature = ? and feature_hash = ? and state in (?)", projectExtension.Model.ID, releaseExtension.ServicesSignature, releaseExtension.SecretsSignature, releaseExtension.FeatureHash, []string{"complete"}).Order("created_at desc").First(&lastReleaseExtension).RecordNotFound() {
-					eventAction = plugins.GetAction("status")
+			if e.State == plugins.GetState("complete") {
+				x.ReleaseExtensionCompleted(&releaseExtension)
+			}
 
-					err := json.Unmarshal(lastReleaseExtension.Artifacts.RawMessage, &artifacts)
-					if err != nil {
-						log.Info(err.Error())
-					}
-				} else {
-					artifacts, err = resolvers.ExtractArtifacts(projectExtension, extension, x.DB)
-					if err != nil {
-						log.Info(err.Error())
-					}
-				}
-
-				payload := plugins.ReleaseExtension{
-					ID:      releaseExtension.Model.ID.String(),
-					Slug:    extension.Key,
-					Release: payload,
-				}
-
-				ev := transistor.NewEvent(transistor.EventName(extension.Key), eventAction, payload)
-				ev.Artifacts = artifacts
-
-				x.Events <- ev
+			if e.State == plugins.GetState("failed") {
+				x.ReleaseFailed(&release, e.StateMessage)
 			}
 		}
+
+		return nil
 	}
-	return nil
-}
 
-func (x *CodeAmp) ReleaseExtensionEventHandler(e transistor.Event) error {
-	payload := e.Payload.(plugins.ReleaseExtension)
+	if e.PayloadModel == "plugins.Release" {
+		payload := e.Payload.(plugins.Release)
+		release := resolvers.Release{}
+		releaseExtensions := []resolvers.ReleaseExtension{}
 
-	var releaseExtension resolvers.ReleaseExtension
-	var release resolvers.Release
-
-	if e.Matches("releaseextension:status") {
-		if x.DB.Where("id = ?", payload.Release.ID).Find(&release).RecordNotFound() {
-			log.InfoWithFields("release", log.Fields{
-				"id": payload.Release.ID,
-			})
-			return fmt.Errorf("Release %s not found", payload.Release.ID)
-		}
-
-		if x.DB.Where("id = ?", payload.ID).Find(&releaseExtension).RecordNotFound() {
-			log.InfoWithFields("release extension not found", log.Fields{
+		if x.DB.Where("id = ?", payload.ID).First(&release).RecordNotFound() {
+			log.InfoWithFields("release not found", log.Fields{
 				"id": payload.ID,
 			})
-			return fmt.Errorf("Release extension %s not found", payload.ID)
+			return fmt.Errorf("release %s not found", payload.ID)
 		}
 
-		marshalledReArtifacts, err := json.Marshal(e.Artifacts)
-		if err != nil {
-			log.Info(err.Error(), log.Fields{})
-			return err
-		}
+		if e.Matches("release:create") {
+			x.DB.Where("release_id = ?", release.Model.ID).Find(&releaseExtensions)
 
-		releaseExtension.Artifacts = postgres.Jsonb{marshalledReArtifacts}
-		x.DB.Save(&releaseExtension)
+			for _, releaseExtension := range releaseExtensions {
+				projectExtension := resolvers.ProjectExtension{}
+				if x.DB.Where("id = ?", releaseExtension.ProjectExtensionID).Find(&projectExtension).RecordNotFound() {
+					log.InfoWithFields("project extensions not found", log.Fields{
+						"id": releaseExtension.ProjectExtensionID,
+						"release_extension_id": releaseExtension.Model.ID,
+					})
+					return fmt.Errorf("project extension %s not found", releaseExtension.ProjectExtensionID)
+				}
 
-		if e.State == plugins.GetState("complete") {
-			x.ReleaseExtensionCompleted(&releaseExtension)
-		}
+				extension := resolvers.Extension{}
+				if x.DB.Where("id= ?", projectExtension.ExtensionID).Find(&extension).RecordNotFound() {
+					log.InfoWithFields("extension not found", log.Fields{
+						"id": projectExtension.Model.ID,
+						"release_extension_id": releaseExtension.Model.ID,
+					})
+					return fmt.Errorf("extension %s not found", projectExtension.ExtensionID)
+				}
 
-		if e.State == plugins.GetState("failed") {
-			x.ReleaseFailed(&release, e.StateMessage)
+				if plugins.Type(extension.Type) == plugins.GetType("workflow") {
+					// check if the last release extension has the same
+					// ServicesSignature and SecretsSignature. If so,
+					// mark the action as completed before sending the event
+					lastReleaseExtension := resolvers.ReleaseExtension{}
+					artifacts := []transistor.Artifact{}
+
+					eventAction := plugins.GetAction("create")
+
+					// check if can cache workflows
+					if !release.ForceRebuild && !x.DB.Where("project_extension_id = ? and services_signature = ? and secrets_signature = ? and feature_hash = ? and state in (?)", projectExtension.Model.ID, releaseExtension.ServicesSignature, releaseExtension.SecretsSignature, releaseExtension.FeatureHash, []string{"complete"}).Order("created_at desc").First(&lastReleaseExtension).RecordNotFound() {
+						eventAction = plugins.GetAction("status")
+
+						err := json.Unmarshal(lastReleaseExtension.Artifacts.RawMessage, &artifacts)
+						if err != nil {
+							log.Info(err.Error())
+						}
+					} else {
+						artifacts, err = resolvers.ExtractArtifacts(projectExtension, extension, x.DB)
+						if err != nil {
+							log.Info(err.Error())
+						}
+					}
+
+					payload := plugins.ReleaseExtension{
+						ID:      releaseExtension.Model.ID.String(),
+						Slug:    extension.Key,
+						Release: payload,
+					}
+
+					ev := transistor.NewEvent(transistor.EventName(fmt.Sprintf("release:%s", extension.Key)), eventAction, payload)
+					ev.Artifacts = artifacts
+
+					x.Events <- ev
+				}
+			}
 		}
 	}
-
 	return nil
 }
 
@@ -864,7 +870,7 @@ func (x *CodeAmp) WorkflowReleaseExtensionsCompleted(release *resolvers.Release)
 				},
 			}
 
-			ev := transistor.NewEvent(transistor.EventName(extension.Key), releaseExtensionAction, releaseExtensionEvent)
+			ev := transistor.NewEvent(transistor.EventName(fmt.Sprintf("release:%s", extension.Key)), releaseExtensionAction, releaseExtensionEvent)
 			ev.Artifacts = _artifacts
 			x.Events <- ev
 

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -783,13 +783,12 @@ func (x *CodeAmp) WorkflowReleaseExtensionsCompleted(release *resolvers.Release)
 		if releaseExtension.Type == plugins.GetType("deployment") {
 			_artifacts := artifacts
 
-			// ADB Needs another look
 			// Fail deployment if the release is in a failed state
-			// if release.State == plugins.GetState("failed") {
-			// 	releaseExtensionAction = plugins.GetAction("status")
-			// 	releaseExtension.State = plugins.GetState("failed")
-			// 	releaseExtension.StateMessage = release.StateMessage
-			// }
+			if release.State == plugins.GetState("failed") {
+				releaseExtensionAction = plugins.GetAction("status")
+				releaseExtension.State = plugins.GetState("failed")
+				releaseExtension.StateMessage = release.StateMessage
+			}
 
 			projectExtension := resolvers.ProjectExtension{}
 			if x.DB.Where("id = ?", releaseExtension.ProjectExtensionID).Find(&projectExtension).RecordNotFound() {
@@ -1104,25 +1103,16 @@ func (x *CodeAmp) RunQueuedReleases(release *resolvers.Release) error {
 }
 
 func (x *CodeAmp) ReleaseFailed(release *resolvers.Release, stateMessage string) {
-	// ADB Please look at
-	// release.State = plugins.GetState("failed")
-	// release.StateMessage = stateMessage
+	release.State = plugins.GetState("failed")
+	release.StateMessage = stateMessage
 	x.DB.Save(release)
 
 	releaseExtensions := []resolvers.ReleaseExtension{}
 	x.DB.Where("release_id = ?", release.Model.ID).Find(&releaseExtensions)
-<<<<<<< HEAD
 	for _, re := range releaseExtensions {
 		re.State = plugins.GetState("failed")
 		x.DB.Save(&re)
 	}
-=======
-	// ADB Please look at
-	// for _, re := range releaseExtensions {
-	// 	re.State = plugins.GetState("failed")
-	// 	re.StateMessage = stateMessage
-	// }
->>>>>>> WIP on codeamp. This commit and the last DEFINITELY need review
 
 	x.RunQueuedReleases(release)
 }
@@ -1143,10 +1133,9 @@ func (x *CodeAmp) ReleaseCompleted(release *resolvers.Release) {
 		})
 	}
 
-	// ADB Please look at
 	// mark release as complete
-	// release.State = plugins.GetState("complete")
-	// release.StateMessage = "Completed"
+	release.State = plugins.GetState("complete")
+	release.StateMessage = "Completed"
 
 	x.DB.Save(release)
 

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -177,14 +177,14 @@ func (x *CodeAmp) Process(e transistor.Event) error {
 	log.Info("Processing CodeAmp event")
 	e.Dump()
 
-	methodName := fmt.Sprintf("%sEventHandler", strings.Split(e.PayloadModel(), ".")[1])
+	methodName := fmt.Sprintf("%sEventHandler", strings.Split(e.PayloadModel, ".")[1])
 
 	if _, ok := reflect.TypeOf(x).MethodByName(methodName); ok {
 		reflect.ValueOf(x).MethodByName(methodName).Call([]reflect.Value{reflect.ValueOf(e)})
 	} else {
 		log.InfoWithFields("*EventHandler not implemented", log.Fields{
 			"event_name":    e.Name,
-			"payload_model": e.PayloadModel(),
+			"payload_model": e.PayloadModel,
 			"method_name":   methodName,
 		})
 	}
@@ -193,7 +193,7 @@ func (x *CodeAmp) Process(e transistor.Event) error {
 }
 
 func (x *CodeAmp) HeartBeatEventHandler(e transistor.Event) {
-	payload := e.Payload().(plugins.HeartBeat)
+	payload := e.Payload.(plugins.HeartBeat)
 
 	var projects []resolvers.Project
 
@@ -207,7 +207,7 @@ func (x *CodeAmp) HeartBeatEventHandler(e transistor.Event) {
 }
 
 func (x *CodeAmp) GitSyncEventHandler(e transistor.Event) error {
-	payload := e.Payload().(plugins.GitSync)
+	payload := e.Payload.(plugins.GitSync)
 
 	var project resolvers.Project
 	var environment resolvers.Environment
@@ -289,7 +289,7 @@ func (x *CodeAmp) GitSyncEventHandler(e transistor.Event) error {
 }
 
 func (x *CodeAmp) WebsocketMsgEventHandler(e transistor.Event) error {
-	payload := e.Payload().(plugins.WebsocketMsg)
+	payload := e.Payload.(plugins.WebsocketMsg)
 
 	if payload.Channel == "" {
 		payload.Channel = "general"
@@ -301,7 +301,7 @@ func (x *CodeAmp) WebsocketMsgEventHandler(e transistor.Event) error {
 }
 
 func (x *CodeAmp) ProjectExtensionEventHandler(e transistor.Event) error {
-	payload := e.Payload().(plugins.ProjectExtension)
+	payload := e.Payload.(plugins.ProjectExtension)
 	var extension resolvers.ProjectExtension
 	var project resolvers.Project
 
@@ -342,7 +342,7 @@ func (x *CodeAmp) ProjectExtensionEventHandler(e transistor.Event) error {
 
 func (x *CodeAmp) ReleaseEventHandler(e transistor.Event) error {
 	var err error
-	payload := e.Payload().(plugins.Release)
+	payload := e.Payload.(plugins.Release)
 	release := resolvers.Release{}
 	releaseExtensions := []resolvers.ReleaseExtension{}
 
@@ -416,7 +416,7 @@ func (x *CodeAmp) ReleaseEventHandler(e transistor.Event) error {
 }
 
 func (x *CodeAmp) ReleaseExtensionEventHandler(e transistor.Event) error {
-	payload := e.Payload().(plugins.ReleaseExtension)
+	payload := e.Payload.(plugins.ReleaseExtension)
 
 	var releaseExtension resolvers.ReleaseExtension
 	var release resolvers.Release
@@ -859,7 +859,7 @@ func (x *CodeAmp) WorkflowReleaseExtensionsCompleted(release *resolvers.Release)
 				},
 			}
 
-			ev := transistor.NewEvent(plugins.GetEventName("releaseextension"), releaseExtensionAction, releaseExtensionEvent)
+			ev := transistor.NewEvent(transistor.EventName(extension.Key), releaseExtensionAction, releaseExtensionEvent)
 			ev.Artifacts = _artifacts
 			x.Events <- ev
 

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -177,14 +177,14 @@ func (x *CodeAmp) Process(e transistor.Event) error {
 	log.Info("Processing CodeAmp event")
 	e.Dump()
 
-	methodName := fmt.Sprintf("%sEventHandler", strings.Split(e.PayloadModel, ".")[1])
+	methodName := fmt.Sprintf("%sEventHandler", strings.Split(e.PayloadModel(), ".")[1])
 
 	if _, ok := reflect.TypeOf(x).MethodByName(methodName); ok {
 		reflect.ValueOf(x).MethodByName(methodName).Call([]reflect.Value{reflect.ValueOf(e)})
 	} else {
 		log.InfoWithFields("*EventHandler not implemented", log.Fields{
 			"event_name":    e.Name,
-			"payload_model": e.PayloadModel,
+			"payload_model": e.PayloadModel(),
 			"method_name":   methodName,
 		})
 	}
@@ -193,7 +193,7 @@ func (x *CodeAmp) Process(e transistor.Event) error {
 }
 
 func (x *CodeAmp) HeartBeatEventHandler(e transistor.Event) {
-	payload := e.Payload.(plugins.HeartBeat)
+	payload := e.Payload().(plugins.HeartBeat)
 
 	var projects []resolvers.Project
 
@@ -207,7 +207,7 @@ func (x *CodeAmp) HeartBeatEventHandler(e transistor.Event) {
 }
 
 func (x *CodeAmp) GitCommitEventHandler(e transistor.Event) error {
-	payload := e.Payload.(plugins.GitCommit)
+	payload := e.Payload().(plugins.GitCommit)
 
 	var project resolvers.Project
 	var environment resolvers.Environment
@@ -285,7 +285,7 @@ func (x *CodeAmp) GitCommitEventHandler(e transistor.Event) error {
 }
 
 func (x *CodeAmp) WebsocketMsgEventHandler(e transistor.Event) error {
-	payload := e.Payload.(plugins.WebsocketMsg)
+	payload := e.Payload().(plugins.WebsocketMsg)
 
 	if payload.Channel == "" {
 		payload.Channel = "general"
@@ -297,7 +297,7 @@ func (x *CodeAmp) WebsocketMsgEventHandler(e transistor.Event) error {
 }
 
 func (x *CodeAmp) ProjectExtensionEventHandler(e transistor.Event) error {
-	payload := e.Payload.(plugins.ProjectExtension)
+	payload := e.Payload().(plugins.ProjectExtension)
 	var extension resolvers.ProjectExtension
 	var project resolvers.Project
 
@@ -338,7 +338,7 @@ func (x *CodeAmp) ProjectExtensionEventHandler(e transistor.Event) error {
 
 func (x *CodeAmp) ReleaseEventHandler(e transistor.Event) error {
 	var err error
-	payload := e.Payload.(plugins.Release)
+	payload := e.Payload().(plugins.Release)
 	release := resolvers.Release{}
 	releaseExtensions := []resolvers.ReleaseExtension{}
 
@@ -412,7 +412,7 @@ func (x *CodeAmp) ReleaseEventHandler(e transistor.Event) error {
 }
 
 func (x *CodeAmp) ReleaseExtensionEventHandler(e transistor.Event) error {
-	payload := e.Payload.(plugins.ReleaseExtension)
+	payload := e.Payload().(plugins.ReleaseExtension)
 
 	var releaseExtension resolvers.ReleaseExtension
 	var release resolvers.Release

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -349,7 +349,7 @@ func (x *CodeAmp) ReleaseEventHandler(e transistor.Event) error {
 		return fmt.Errorf("release %s not found", payload.ID)
 	}
 
-	if e.Matches("plugins.Release:create") {
+	if e.Matches("release:create") {
 		x.DB.Where("release_id = ?", release.Model.ID).Find(&releaseExtensions)
 
 		for _, releaseExtension := range releaseExtensions {

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -1119,7 +1119,7 @@ func (x *CodeAmp) ReleaseFailed(release *resolvers.Release, stateMessage string)
 	x.DB.Save(release)
 
 	releaseExtensions := []resolvers.ReleaseExtension{}
-	x.DB.Where("release_id = ?", release.Model.ID).Find(&releaseExtensions)
+	x.DB.Where("release_id = ? AND state <> ?", release.Model.ID, transistor.GetState("complete")).Find(&releaseExtensions)
 	for _, re := range releaseExtensions {
 		re.State = transistor.GetState("failed")
 		x.DB.Save(&re)

--- a/plugins/codeamp/migrations.go
+++ b/plugins/codeamp/migrations.go
@@ -219,11 +219,11 @@ func (x *CodeAmp) Migrate() {
 					db.Where("key = ? AND environment_id = ?", "DOCKER_PASS", environment.Model.ID).FirstOrInit(&dockerPass)
 
 					config = []map[string]interface{}{
-						map[string]interface{}{"key": "ORG", "value": dockerOrg.Model.ID.String()},
-						map[string]interface{}{"key": "HOST", "value": dockerHost.Model.ID.String()},
-						map[string]interface{}{"key": "USER", "value": dockerUser.Model.ID.String()},
-						map[string]interface{}{"key": "EMAIL", "value": dockerEmail.Model.ID.String()},
-						map[string]interface{}{"key": "PASSWORD", "value": dockerPass.Model.ID.String()},
+						{"key": "ORG", "value": dockerOrg.Model.ID.String()},
+						{"key": "HOST", "value": dockerHost.Model.ID.String()},
+						{"key": "USER", "value": dockerUser.Model.ID.String()},
+						{"key": "EMAIL", "value": dockerEmail.Model.ID.String()},
+						{"key": "PASSWORD", "value": dockerPass.Model.ID.String()},
 					}
 
 					marshalledConfig, err = json.Marshal(config)
@@ -271,15 +271,15 @@ func (x *CodeAmp) Migrate() {
 					db.Where("key = ? AND environment_id = ?", "CERTIFICATE_AUTHORITY", environment.Model.ID).FirstOrInit(&certificateAuthority)
 
 					config = []map[string]interface{}{
-						map[string]interface{}{"key": "SSL_CERT_ARN", "value": sslArn.Model.ID.String()},
-						map[string]interface{}{"key": "ACCESS_LOG_S3_BUCKET", "value": s3Bucket.Model.ID.String()},
-						map[string]interface{}{"key": "HOSTED_ZONE_ID", "value": hostedZoneID.Model.ID.String()},
-						map[string]interface{}{"key": "HOSTED_ZONE_NAME", "value": hostedZoneName.Model.ID.String()},
-						map[string]interface{}{"key": "AWS_ACCESS_KEY_ID", "value": awsAccessKeyID.Model.ID.String()},
-						map[string]interface{}{"key": "AWS_SECRET_KEY", "value": awsSecretKey.Model.ID.String()},
-						map[string]interface{}{"key": "CLIENT_CERTIFICATE", "value": clientCert.Model.ID.String()},
-						map[string]interface{}{"key": "CLIENT_KEY", "value": clientKey.Model.ID.String()},
-						map[string]interface{}{"key": "CERTIFICATE_AUTHORITY", "value": certificateAuthority.Model.ID.String()},
+						{"key": "SSL_CERT_ARN", "value": sslArn.Model.ID.String()},
+						{"key": "ACCESS_LOG_S3_BUCKET", "value": s3Bucket.Model.ID.String()},
+						{"key": "HOSTED_ZONE_ID", "value": hostedZoneID.Model.ID.String()},
+						{"key": "HOSTED_ZONE_NAME", "value": hostedZoneName.Model.ID.String()},
+						{"key": "AWS_ACCESS_KEY_ID", "value": awsAccessKeyID.Model.ID.String()},
+						{"key": "AWS_SECRET_KEY", "value": awsSecretKey.Model.ID.String()},
+						{"key": "CLIENT_CERTIFICATE", "value": clientCert.Model.ID.String()},
+						{"key": "CLIENT_KEY", "value": clientKey.Model.ID.String()},
+						{"key": "CERTIFICATE_AUTHORITY", "value": certificateAuthority.Model.ID.String()},
 					}
 
 					marshalledConfig, err = json.Marshal(config)
@@ -309,10 +309,10 @@ func (x *CodeAmp) Migrate() {
 					db.Where("key = ? AND environment_id = ?", "CERTIFICATE_AUTHORITY", environment.Model.ID).FirstOrInit(&certificateAuthority)
 
 					config = []map[string]interface{}{
-						map[string]interface{}{"key": "KUBECONFIG", "value": kubeConfig.Model.ID.String()},
-						map[string]interface{}{"key": "CLIENT_CERTIFICATE", "value": clientCert.Model.ID.String()},
-						map[string]interface{}{"key": "CLIENT_KEY", "value": clientKey.Model.ID.String()},
-						map[string]interface{}{"key": "CERTIFICATE_AUTHORITY", "value": certificateAuthority.Model.ID.String()},
+						{"key": "KUBECONFIG", "value": kubeConfig.Model.ID.String()},
+						{"key": "CLIENT_CERTIFICATE", "value": clientCert.Model.ID.String()},
+						{"key": "CLIENT_KEY", "value": clientKey.Model.ID.String()},
+						{"key": "CERTIFICATE_AUTHORITY", "value": certificateAuthority.Model.ID.String()},
 					}
 
 					marshalledConfig, err = json.Marshal(config)

--- a/plugins/codeamp/resolvers/environment_test.go
+++ b/plugins/codeamp/resolvers/environment_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	resolvers "github.com/codeamp/circuit/plugins/codeamp/resolvers"
+	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
-	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -64,7 +64,7 @@ func (suite *EnvironmentTestSuite) TestCreateEnvironment() {
 	assert.Equal(suite.T(), envResolver.Color(), "color")
 	assert.NotEqual(suite.T(), envResolver.Color(), "wrongcolor")
 
-	suite.TearDownTest([]string{envResolver.Model.ID.String()})
+	suite.TearDownTest([]string{envResolver.Environment.Model.ID.String()})
 }
 
 /* Test successful env. update */
@@ -82,7 +82,7 @@ func (suite *EnvironmentTestSuite) TestUpdateEnvironment() {
 	}
 
 	// update environment's name with same id
-	envId := envResolver.Model.ID.String()
+	envId := envResolver.Environment.Model.ID.String()
 	envInput.ID = &envId
 	envInput.Color = "red"
 	envInput.Name = "test2"
@@ -96,14 +96,14 @@ func (suite *EnvironmentTestSuite) TestUpdateEnvironment() {
 		log.Fatal(err.Error())
 	}
 
-	assert.Equal(suite.T(), updateEnvResolver.ID(), graphql.ID(envResolver.Model.ID.String()))
+	assert.Equal(suite.T(), updateEnvResolver.ID(), graphql.ID(envResolver.Environment.Model.ID.String()))
 	assert.Equal(suite.T(), updateEnvResolver.Name(), "test2")
 	assert.Equal(suite.T(), updateEnvResolver.Color(), "red")
 	assert.Equal(suite.T(), updateEnvResolver.Key(), "foo")
 	assert.Equal(suite.T(), updateEnvResolver.IsDefault(), true)
 	assert.NotEqual(suite.T(), updateEnvResolver.Name(), "diffkey")
 
-	suite.TearDownTest([]string{updateEnvResolver.Model.ID.String()})
+	suite.TearDownTest([]string{updateEnvResolver.Environment.Model.ID.String()})
 }
 
 func (suite *EnvironmentTestSuite) TestCreate2EnvsUpdateFirstEnvironmentIsDefaultToFalse() {
@@ -137,7 +137,7 @@ func (suite *EnvironmentTestSuite) TestCreate2EnvsUpdateFirstEnvironmentIsDefaul
 	assert.Equal(suite.T(), envResolver2.Key(), "foo2")
 
 	envInput.IsDefault = false
-	envId := envResolver.Model.ID.String()
+	envId := envResolver.Environment.Model.ID.String()
 	envInput.ID = &envId
 
 	updateEnvResolver, err := suite.Resolver.UpdateEnvironment(nil, &struct{ Environment *resolvers.EnvironmentInput }{Environment: &envInput})
@@ -149,7 +149,7 @@ func (suite *EnvironmentTestSuite) TestCreate2EnvsUpdateFirstEnvironmentIsDefaul
 
 	// IsDefault SHOULD be ignored since it's the only default env left
 	envInput2.IsDefault = false
-	envId = envResolver2.Model.ID.String()
+	envId = envResolver2.Environment.Model.ID.String()
 	envInput2.ID = &envId
 
 	updateEnvResolver2, err := suite.Resolver.UpdateEnvironment(nil, &struct{ Environment *resolvers.EnvironmentInput }{Environment: &envInput2})
@@ -159,7 +159,7 @@ func (suite *EnvironmentTestSuite) TestCreate2EnvsUpdateFirstEnvironmentIsDefaul
 
 	assert.Equal(suite.T(), updateEnvResolver2.IsDefault(), true)
 
-	suite.TearDownTest([]string{envResolver.Model.ID.String(), envResolver2.Model.ID.String()})
+	suite.TearDownTest([]string{envResolver.Environment.Model.ID.String(), envResolver2.Environment.Model.ID.String()})
 }
 
 func (suite *EnvironmentTestSuite) TearDownTest(ids []string) {

--- a/plugins/codeamp/resolvers/extension.go
+++ b/plugins/codeamp/resolvers/extension.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
+	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/jinzhu/gorm"
 	"github.com/jinzhu/gorm/dialects/postgres"
-	graphql "github.com/graph-gophers/graphql-go"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/plugins/codeamp/resolvers/feature.go
+++ b/plugins/codeamp/resolvers/feature.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/jinzhu/gorm"
 	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/plugins/codeamp/resolvers/mutation.go
+++ b/plugins/codeamp/resolvers/mutation.go
@@ -224,8 +224,8 @@ func (r *Resolver) StopRelease(ctx context.Context, args *struct{ ID graphql.ID 
 		return nil, errors.New("Release Not Found")
 	}
 
-	release.State = plugins.GetState("failed")
-	release.StateMessage = fmt.Sprintf("Release stopped by %s", user.Email)
+	// release.State = plugins.GetState("failed")
+	// release.StateMessage = fmt.Sprintf("Release stopped by %s", user.Email)
 	r.DB.Save(&release)
 
 	for _, releaseExtension := range releaseExtensions {
@@ -254,14 +254,13 @@ func (r *Resolver) StopRelease(ctx context.Context, args *struct{ ID graphql.ID 
 		}
 
 		if releaseExtension.State == plugins.GetState("waiting") {
-
 			releaseExtensionEvent := plugins.ReleaseExtension{
-				ID:           releaseExtension.ID.String(),
-				Action:       plugins.GetAction("status"),
-				Slug:         extension.Key,
-				State:        plugins.GetState("failed"),
-				StateMessage: fmt.Sprintf("Deployment Stopped By User %s", user.Email),
-				Project:      plugins.Project{},
+				ID: releaseExtension.ID.String(),
+				// Action:       plugins.GetAction("status"),
+				Slug: extension.Key,
+				// State:        plugins.GetState("failed"),
+				// StateMessage: fmt.Sprintf("Deployment Stopped By User %s", user.Email),
+				Project: plugins.Project{},
 				Release: plugins.Release{
 					ID: releaseExtension.ReleaseID.String(),
 				},

--- a/plugins/codeamp/resolvers/mutation.go
+++ b/plugins/codeamp/resolvers/mutation.go
@@ -464,6 +464,7 @@ func (r *Resolver) CreateRelease(ctx context.Context, args *struct{ Release *Rel
 	// Create Release
 	release := Release{
 		State:             transistor.GetState("waiting"),
+		StateMessage:      "Release created",
 		ProjectID:         projectID,
 		EnvironmentID:     environmentID,
 		UserID:            uuid.FromStringOrNil(userID),
@@ -669,13 +670,14 @@ func (r *Resolver) CreateRelease(ctx context.Context, args *struct{ Release *Rel
 
 			// create ReleaseExtension
 			releaseExtension := ReleaseExtension{
+				State:              transistor.GetState("waiting"),
+				StateMessage:       "",
 				ReleaseID:          release.Model.ID,
 				FeatureHash:        headFeature.Hash,
 				ServicesSignature:  fmt.Sprintf("%x", servicesSig),
 				SecretsSignature:   fmt.Sprintf("%x", secretsSig),
 				ProjectExtensionID: projectExtension.Model.ID,
 				Type:               extension.Type,
-				State:              transistor.GetState("waiting"),
 			}
 
 			r.DB.Create(&releaseExtension)
@@ -1256,6 +1258,7 @@ func (r *Resolver) CreateProjectExtension(ctx context.Context, args *struct{ Pro
 		}
 
 		projectExtension = ProjectExtension{
+			State:         transistor.GetState("waiting"),
 			ExtensionID:   extension.Model.ID,
 			ProjectID:     project.Model.ID,
 			EnvironmentID: env.Model.ID,
@@ -1376,6 +1379,8 @@ func (r *Resolver) UpdateProjectExtension(args *struct{ ProjectExtension *Projec
 
 	projectExtension.Config = postgres.Jsonb{args.ProjectExtension.Config.RawMessage}
 	projectExtension.CustomConfig = postgres.Jsonb{args.ProjectExtension.CustomConfig.RawMessage}
+	projectExtension.State = transistor.GetState("waiting")
+	projectExtension.StateMessage = ""
 
 	r.DB.Save(&projectExtension)
 

--- a/plugins/codeamp/resolvers/mutation.go
+++ b/plugins/codeamp/resolvers/mutation.go
@@ -353,7 +353,7 @@ func (r *Resolver) CreateRelease(ctx context.Context, args *struct{ Release *Rel
 
 		projectExtensionsJsonb = postgres.Jsonb{projectExtensionsMarshaled}
 	} else {
-		log.Info(fmt.Sprintf("Existing Release. Rolling back %s", args.Release.ID))
+		log.Info(fmt.Sprintf("Existing Release. Rolling back %d", args.Release.ID))
 		// Rollback
 		release := Release{}
 

--- a/plugins/codeamp/resolvers/mutation.go
+++ b/plugins/codeamp/resolvers/mutation.go
@@ -264,7 +264,7 @@ func (r *Resolver) StopRelease(ctx context.Context, args *struct{ ID graphql.ID 
 			},
 			Environment: "",
 		}
-		event := transistor.NewEvent(plugins.GetEventName("releaseextension"), plugins.GetAction("create"), releaseExtensionEvent)
+		event := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("create"), releaseExtensionEvent)
 		event.State = plugins.GetState("failed")
 		event.StateMessage = fmt.Sprintf("Deployment Stopped By User %s", user.Email)
 		r.Events <- event
@@ -686,7 +686,7 @@ func (r *Resolver) CreateRelease(ctx context.Context, args *struct{ Release *Rel
 		log.Info(fmt.Sprintf("Release is already running, queueing %s", release.Model.ID.String()))
 		return &ReleaseResolver{}, fmt.Errorf("Release is already running, queuing %s", release.Model.ID.String())
 	} else {
-		r.Events <- transistor.NewEvent(plugins.GetEventName("releaseextension"), plugins.GetAction("create"), releaseEvent)
+		r.Events <- transistor.NewEvent(transistor.EventName("release"), plugins.GetAction("create"), releaseEvent)
 
 		return &ReleaseResolver{DB: r.DB, Release: Release{}}, nil
 	}
@@ -1280,7 +1280,7 @@ func (r *Resolver) CreateProjectExtension(ctx context.Context, args *struct{ Pro
 			},
 			Environment: env.Key,
 		}
-		ev := transistor.NewEvent(plugins.GetEventName("projectextension"), plugins.GetAction("create"), projectExtensionEvent)
+		ev := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("create"), projectExtensionEvent)
 		ev.Artifacts = artifacts
 		r.Events <- ev
 
@@ -1396,7 +1396,7 @@ func (r *Resolver) UpdateProjectExtension(args *struct{ ProjectExtension *Projec
 		Environment: env.Key,
 	}
 
-	ev := transistor.NewEvent(plugins.GetEventName("projectextension"), plugins.GetAction("update"), projectExtensionEvent)
+	ev := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("update"), projectExtensionEvent)
 	ev.Artifacts = artifacts
 
 	r.Events <- ev
@@ -1468,7 +1468,7 @@ func (r *Resolver) DeleteProjectExtension(args *struct{ ProjectExtension *Projec
 		},
 		Environment: env.Key,
 	}
-	ev := transistor.NewEvent(plugins.GetEventName("projectextension"), plugins.GetAction("destroy"), projectExtensionEvent)
+	ev := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("destroy"), projectExtensionEvent)
 	ev.Artifacts = artifacts
 	r.Events <- ev
 

--- a/plugins/codeamp/resolvers/mutation.go
+++ b/plugins/codeamp/resolvers/mutation.go
@@ -263,7 +263,7 @@ func (r *Resolver) StopRelease(ctx context.Context, args *struct{ ID graphql.ID 
 				},
 				Environment: "",
 			}
-			event := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("create"), releaseExtensionEvent)
+			event := transistor.NewEvent(transistor.EventName(fmt.Sprintf("release:%s", extension.Key)), plugins.GetAction("create"), releaseExtensionEvent)
 			event.State = plugins.GetState("failed")
 			event.StateMessage = fmt.Sprintf("Deployment Stopped By User %s", user.Email)
 			r.Events <- event
@@ -675,6 +675,7 @@ func (r *Resolver) CreateRelease(ctx context.Context, args *struct{ Release *Rel
 				SecretsSignature:   fmt.Sprintf("%x", secretsSig),
 				ProjectExtensionID: projectExtension.Model.ID,
 				Type:               extension.Type,
+				State:              plugins.GetState("waiting"),
 			}
 
 			r.DB.Create(&releaseExtension)
@@ -1279,7 +1280,7 @@ func (r *Resolver) CreateProjectExtension(ctx context.Context, args *struct{ Pro
 			},
 			Environment: env.Key,
 		}
-		ev := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("create"), projectExtensionEvent)
+		ev := transistor.NewEvent(transistor.EventName(fmt.Sprintf("project:%s", extension.Key)), plugins.GetAction("create"), projectExtensionEvent)
 		ev.Artifacts = artifacts
 		r.Events <- ev
 
@@ -1395,7 +1396,7 @@ func (r *Resolver) UpdateProjectExtension(args *struct{ ProjectExtension *Projec
 		Environment: env.Key,
 	}
 
-	ev := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("update"), projectExtensionEvent)
+	ev := transistor.NewEvent(transistor.EventName(fmt.Sprintf("project:%s", extension.Key)), plugins.GetAction("update"), projectExtensionEvent)
 	ev.Artifacts = artifacts
 
 	r.Events <- ev
@@ -1467,7 +1468,7 @@ func (r *Resolver) DeleteProjectExtension(args *struct{ ProjectExtension *Projec
 		},
 		Environment: env.Key,
 	}
-	ev := transistor.NewEvent(transistor.EventName(extension.Key), plugins.GetAction("destroy"), projectExtensionEvent)
+	ev := transistor.NewEvent(transistor.EventName(fmt.Sprintf("project:%s", extension.Key)), plugins.GetAction("destroy"), projectExtensionEvent)
 	ev.Artifacts = artifacts
 	r.Events <- ev
 

--- a/plugins/codeamp/resolvers/mutation.go
+++ b/plugins/codeamp/resolvers/mutation.go
@@ -264,7 +264,7 @@ func (r *Resolver) StopRelease(ctx context.Context, args *struct{ ID graphql.ID 
 			},
 			Environment: "",
 		}
-		event := transistor.NewEvent(plugins.GetEventName("release"), plugins.GetAction("create"), releaseExtensionEvent)
+		event := transistor.NewEvent(plugins.GetEventName("releaseextension"), plugins.GetAction("create"), releaseExtensionEvent)
 		event.State = plugins.GetState("failed")
 		event.StateMessage = fmt.Sprintf("Deployment Stopped By User %s", user.Email)
 		r.Events <- event
@@ -686,7 +686,7 @@ func (r *Resolver) CreateRelease(ctx context.Context, args *struct{ Release *Rel
 		log.Info(fmt.Sprintf("Release is already running, queueing %s", release.Model.ID.String()))
 		return &ReleaseResolver{}, fmt.Errorf("Release is already running, queuing %s", release.Model.ID.String())
 	} else {
-		r.Events <- transistor.NewEvent(plugins.GetEventName("release"), plugins.GetAction("create"), releaseEvent)
+		r.Events <- transistor.NewEvent(plugins.GetEventName("releaseextension"), plugins.GetAction("create"), releaseEvent)
 
 		return &ReleaseResolver{DB: r.DB, Release: Release{}}, nil
 	}
@@ -1280,7 +1280,7 @@ func (r *Resolver) CreateProjectExtension(ctx context.Context, args *struct{ Pro
 			},
 			Environment: env.Key,
 		}
-		ev := transistor.NewEvent(plugins.GetEventName("project"), plugins.GetAction("create"), projectExtensionEvent)
+		ev := transistor.NewEvent(plugins.GetEventName("projectextension"), plugins.GetAction("create"), projectExtensionEvent)
 		ev.Artifacts = artifacts
 		r.Events <- ev
 
@@ -1396,7 +1396,7 @@ func (r *Resolver) UpdateProjectExtension(args *struct{ ProjectExtension *Projec
 		Environment: env.Key,
 	}
 
-	ev := transistor.NewEvent(plugins.GetEventName("project"), plugins.GetAction("update"), projectExtensionEvent)
+	ev := transistor.NewEvent(plugins.GetEventName("projectextension"), plugins.GetAction("update"), projectExtensionEvent)
 	ev.Artifacts = artifacts
 
 	r.Events <- ev
@@ -1468,7 +1468,7 @@ func (r *Resolver) DeleteProjectExtension(args *struct{ ProjectExtension *Projec
 		},
 		Environment: env.Key,
 	}
-	ev := transistor.NewEvent(plugins.GetEventName("project"), plugins.GetAction("destroy"), projectExtensionEvent)
+	ev := transistor.NewEvent(plugins.GetEventName("projectextension"), plugins.GetAction("destroy"), projectExtensionEvent)
 	ev.Artifacts = artifacts
 	r.Events <- ev
 

--- a/plugins/codeamp/resolvers/project.go
+++ b/plugins/codeamp/resolvers/project.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
+	"github.com/codeamp/transistor"
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
@@ -131,7 +131,7 @@ func (r *ProjectResolver) Features(args *struct{ ShowDeployed *bool }) []*Featur
 	if !showDeployed {
 		var currentRelease Release
 
-		if r.DB.Where("state = ? and project_id = ? and environment_id = ?", plugins.GetState("complete"), r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc").First(&currentRelease).RecordNotFound() {
+		if r.DB.Where("state = ? and project_id = ? and environment_id = ?", transistor.GetState("complete"), r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc").First(&currentRelease).RecordNotFound() {
 
 		} else {
 			feature := Feature{}
@@ -153,9 +153,9 @@ func (r *ProjectResolver) Features(args *struct{ ShowDeployed *bool }) []*Featur
 func (r *ProjectResolver) CurrentRelease() (*ReleaseResolver, error) {
 	var currentRelease Release
 
-	if r.DB.Where("state = ? and project_id = ? and environment_id = ?", plugins.GetState("complete"), r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc").First(&currentRelease).RecordNotFound() {
+	if r.DB.Where("state = ? and project_id = ? and environment_id = ?", transistor.GetState("complete"), r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc").First(&currentRelease).RecordNotFound() {
 		log.InfoWithFields("currentRelease does not exist", log.Fields{
-			"state":          plugins.GetState("complete"),
+			"state":          transistor.GetState("complete"),
 			"project_id":     r.Project.Model.ID,
 			"environment_id": r.Environment.Model.ID,
 		})

--- a/plugins/codeamp/resolvers/project.go
+++ b/plugins/codeamp/resolvers/project.go
@@ -218,7 +218,7 @@ func (r *ProjectResolver) Extensions() ([]*ProjectExtensionResolver, error) {
 			WHEN 'workflow' THEN 1
 			WHEN 'deployment' THEN 2
 			ELSE 3
-		END, extensions.key ASC`).Find(&rows)	
+		END, extensions.key ASC`).Find(&rows)
 
 	for _, extension := range rows {
 		results = append(results, &ProjectExtensionResolver{DB: r.DB, ProjectExtension: extension})

--- a/plugins/codeamp/resolvers/project_test.go
+++ b/plugins/codeamp/resolvers/project_test.go
@@ -110,7 +110,7 @@ func (suite *ProjectTestSuite) TestUpdateProjectEnvironments() {
 	projectEnvironmentsInput := resolvers.ProjectEnvironmentsInput{
 		ProjectID: project.Model.ID.String(),
 		Permissions: []resolvers.ProjectEnvironmentInput{
-			resolvers.ProjectEnvironmentInput{
+			{
 				EnvironmentID: env.Model.ID.String(),
 				Grant:         true,
 			},

--- a/plugins/codeamp/resolvers/projectextension.go
+++ b/plugins/codeamp/resolvers/projectextension.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
+	"github.com/codeamp/transistor"
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/jinzhu/gorm"
 	"github.com/jinzhu/gorm/dialects/postgres"
@@ -20,7 +20,7 @@ type ProjectExtension struct {
 	// ExtensionID
 	ExtensionID uuid.UUID `json:"extID" gorm:"type:uuid"`
 	// State
-	State plugins.State `json:"state"`
+	State transistor.State `json:"state"`
 	// StateMessage
 	StateMessage string `json:"stateMessage"`
 	// Artifacts

--- a/plugins/codeamp/resolvers/release.go
+++ b/plugins/codeamp/resolvers/release.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
 	graphql "github.com/graph-gophers/graphql-go"
@@ -19,7 +18,7 @@ import (
 type Release struct {
 	Model `json:",inline"`
 	// State
-	State plugins.State `json:"state"`
+	State transistor.State `json:"state"`
 	// StateMessage
 	StateMessage string `json:"stateMessage"`
 	// ProjectID

--- a/plugins/codeamp/resolvers/releaseextension.go
+++ b/plugins/codeamp/resolvers/releaseextension.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
+	"github.com/codeamp/transistor"
+	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/jinzhu/gorm"
 	"github.com/jinzhu/gorm/dialects/postgres"
-	graphql "github.com/graph-gophers/graphql-go"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -27,7 +28,7 @@ type ReleaseExtension struct {
 	// ProjectExtensionID
 	ProjectExtensionID uuid.UUID `json:"extensionID" gorm:"type:uuid"`
 	// State
-	State plugins.State `json:"state"`
+	State transistor.State `json:"state"`
 	// StateMessage
 	StateMessage string `json:"stateMessage"`
 	// Type

--- a/plugins/codeamp/resolvers/resolver.go
+++ b/plugins/codeamp/resolvers/resolver.go
@@ -62,7 +62,7 @@ func (resolver *Resolver) AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		bearerToken := authString[7:len(authString)]
+		bearerToken := authString[7:]
 
 		// Initialize a provider by specifying dex's issuer URL.
 		provider, err := oidc.NewProvider(ctx, viper.GetString("plugins.codeamp.oidc_uri"))

--- a/plugins/codeamp/resolvers/service.go
+++ b/plugins/codeamp/resolvers/service.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
-	"github.com/jinzhu/gorm"
 	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/plugins/codeamp/resolvers/servicespec.go
+++ b/plugins/codeamp/resolvers/servicespec.go
@@ -3,8 +3,8 @@ package codeamp_resolvers
 import (
 	"encoding/json"
 
-	"github.com/jinzhu/gorm"
 	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/jinzhu/gorm"
 )
 
 // ServiceSpec

--- a/plugins/codeamp/resolvers/user.go
+++ b/plugins/codeamp/resolvers/user.go
@@ -1,11 +1,11 @@
 package codeamp_resolvers
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 
-	"github.com/jinzhu/gorm"
 	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/jinzhu/gorm"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -28,7 +28,7 @@ type DockerBuilder struct {
 func init() {
 	transistor.RegisterPlugin("dockerbuilder", func() transistor.Plugin {
 		return &DockerBuilder{Socket: "unix:///var/run/docker.sock"}
-	})
+	}, plugins.ReleaseExtension{})
 }
 
 func (x *DockerBuilder) Description() string {

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -295,20 +295,20 @@ func (x *DockerBuilder) push(repoPath string, event transistor.Event, buildlog i
 func (x *DockerBuilder) Process(e transistor.Event) error {
 	if e.PayloadModel == "plugins.ProjectExtension" {
 		if e.Event() == "dockerbuilder:create" {
-			ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Installation complete.")
+			ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Installation complete.")
 			x.events <- ev
 			return nil
 		}
 
 		if e.Event() == "dockerbuilder:update" {
-			ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Update complete.")
+			ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Update complete.")
 			x.events <- ev
 			return nil
 		}
 	}
 
 	if e.PayloadModel == "plugins.ReleaseExtension" {
-		x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("fetching"), "Fetching resources.")
+		x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("running"), "Fetching resources.")
 		payload := e.Payload.(plugins.ReleaseExtension)
 
 		repoPath := fmt.Sprintf("%s", payload.Release.Project.Repository)
@@ -319,7 +319,7 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 		err = x.bootstrap(repoPath, e)
 		if err != nil {
 			log.Error(err)
-			x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: bootstrap)", err.Error(), e.State))
+			x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: bootstrap)", err.Error(), e.State))
 			return err
 		}
 
@@ -327,7 +327,7 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 		if err != nil {
 			log.Error(err)
 
-			ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: build)", err.Error(), e.State))
+			ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: build)", err.Error(), e.State))
 			ev.AddArtifact("build_log", buildlogBuf.String(), false)
 			x.events <- ev
 
@@ -338,7 +338,7 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 		if err != nil {
 			log.Error(err)
 
-			ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: push)", err.Error(), e.State))
+			ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: push)", err.Error(), e.State))
 			ev.AddArtifact("build_log", buildlogBuf.String(), false)
 			x.events <- ev
 
@@ -365,7 +365,7 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 			log.Error(err)
 		}
 
-		ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Completed")
+		ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Completed")
 		ev.AddArtifact("user", user.String(), user.Secret)
 		ev.AddArtifact("password", password.String(), password.Secret)
 		ev.AddArtifact("email", email.String(), email.Secret)

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -98,7 +98,7 @@ func (x *DockerBuilder) git(env []string, args ...string) ([]byte, error) {
 }
 
 func (x *DockerBuilder) bootstrap(repoPath string, event transistor.Event) error {
-	payload := event.Payload.(plugins.ReleaseExtension)
+	payload := event.Payload().(plugins.ReleaseExtension)
 
 	var err error
 	var output []byte
@@ -160,7 +160,7 @@ func (x *DockerBuilder) bootstrap(repoPath string, event transistor.Event) error
 }
 
 func (x *DockerBuilder) build(repoPath string, event transistor.Event, dockerBuildOut io.Writer) error {
-	payload := event.Payload.(plugins.ReleaseExtension)
+	payload := event.Payload().(plugins.ReleaseExtension)
 
 	repoPath = fmt.Sprintf("%s/%s_%s", viper.GetString("plugins.dockerbuilder.workdir"), payload.Release.Project.Repository, payload.Release.Git.Branch)
 	gitArchive := exec.Command("git", "archive", payload.Release.HeadFeature.Hash)
@@ -306,7 +306,7 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 	}
 
 	x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("fetching"), "Fetching resources.")
-	payload := e.Payload.(plugins.ReleaseExtension)
+	payload := e.Payload().(plugins.ReleaseExtension)
 
 	// repoPath := fmt.Sprintf("%s/%s_%s", payload.Release.Git.Workdir, payload.Release.Project.Repository, payload.Release.Git.Branch)
 	repoPath := fmt.Sprintf("%s", payload.Release.Project.Repository)
@@ -378,12 +378,12 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 
 // generate image tag name
 func imageTagGen(event transistor.Event) string {
-	payload := event.Payload.(plugins.ReleaseExtension)
+	payload := event.Payload().(plugins.ReleaseExtension)
 	return (fmt.Sprintf("%s.%s", payload.Release.HeadFeature.Hash, payload.Release.Environment))
 }
 
 func imageTagLatest(event transistor.Event) string {
-	payload := event.Payload.(plugins.ReleaseExtension)
+	payload := event.Payload().(plugins.ReleaseExtension)
 	if payload.Release.Environment == "production" {
 		return ("latest")
 	}
@@ -402,7 +402,7 @@ func imagePathGen(event transistor.Event) string {
 		log.Error(err)
 	}
 
-	payload := event.Payload.(plugins.ReleaseExtension)
+	payload := event.Payload().(plugins.ReleaseExtension)
 	return (fmt.Sprintf("%s/%s/%s", registryHost.String(), registryOrg.String(), slug.Slug(payload.Release.Project.Repository)))
 }
 

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -68,8 +68,9 @@ func (x *DockerBuilder) Stop() {
 
 func (x *DockerBuilder) Subscribe() []string {
 	return []string{
-		"dockerbuilder:create",
-		"dockerbuilder:update",
+		"project:dockerbuilder:create",
+		"project:dockerbuilder:update",
+		"release:dockerbuilder:create",
 	}
 }
 
@@ -293,21 +294,21 @@ func (x *DockerBuilder) push(repoPath string, event transistor.Event, buildlog i
 }
 
 func (x *DockerBuilder) Process(e transistor.Event) error {
-	if e.PayloadModel == "plugins.ProjectExtension" {
-		if e.Event() == "dockerbuilder:create" {
+	if e.Matches("project:dockerbuilder") {
+		if e.Action == transistor.GetAction("create") {
 			ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Installation complete.")
 			x.events <- ev
 			return nil
 		}
 
-		if e.Event() == "dockerbuilder:update" {
+		if e.Action == transistor.GetAction("update") {
 			ev := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Update complete.")
 			x.events <- ev
 			return nil
 		}
 	}
 
-	if e.PayloadModel == "plugins.ReleaseExtension" {
+	if e.Matches("release:dockerbuilder") {
 		x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("running"), "Fetching resources.")
 		payload := e.Payload.(plugins.ReleaseExtension)
 

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -98,7 +98,7 @@ func (x *DockerBuilder) git(env []string, args ...string) ([]byte, error) {
 }
 
 func (x *DockerBuilder) bootstrap(repoPath string, event transistor.Event) error {
-	payload := event.Payload().(plugins.ReleaseExtension)
+	payload := event.Payload.(plugins.ReleaseExtension)
 
 	var err error
 	var output []byte
@@ -160,7 +160,7 @@ func (x *DockerBuilder) bootstrap(repoPath string, event transistor.Event) error
 }
 
 func (x *DockerBuilder) build(repoPath string, event transistor.Event, dockerBuildOut io.Writer) error {
-	payload := event.Payload().(plugins.ReleaseExtension)
+	payload := event.Payload.(plugins.ReleaseExtension)
 
 	repoPath = fmt.Sprintf("%s/%s_%s", viper.GetString("plugins.dockerbuilder.workdir"), payload.Release.Project.Repository, payload.Release.Git.Branch)
 	gitArchive := exec.Command("git", "archive", payload.Release.HeadFeature.Hash)
@@ -293,7 +293,7 @@ func (x *DockerBuilder) push(repoPath string, event transistor.Event, buildlog i
 }
 
 func (x *DockerBuilder) Process(e transistor.Event) error {
-	if e.PayloadModel() == "plugins.ProjectExtension" {
+	if e.PayloadModel == "plugins.ProjectExtension" {
 		if e.Event() == "dockerbuilder:create" {
 			ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Installation complete.")
 			x.events <- ev
@@ -307,9 +307,9 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 		}
 	}
 
-	if e.PayloadModel() == "plugins.ReleaseExtension" {
+	if e.PayloadModel == "plugins.ReleaseExtension" {
 		x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("fetching"), "Fetching resources.")
-		payload := e.Payload().(plugins.ReleaseExtension)
+		payload := e.Payload.(plugins.ReleaseExtension)
 
 		repoPath := fmt.Sprintf("%s", payload.Release.Project.Repository)
 		buildlogBuf := bytes.NewBuffer(nil)
@@ -380,12 +380,12 @@ func (x *DockerBuilder) Process(e transistor.Event) error {
 
 // generate image tag name
 func imageTagGen(event transistor.Event) string {
-	payload := event.Payload().(plugins.ReleaseExtension)
+	payload := event.Payload.(plugins.ReleaseExtension)
 	return (fmt.Sprintf("%s.%s", payload.Release.HeadFeature.Hash, payload.Release.Environment))
 }
 
 func imageTagLatest(event transistor.Event) string {
-	payload := event.Payload().(plugins.ReleaseExtension)
+	payload := event.Payload.(plugins.ReleaseExtension)
 	if payload.Release.Environment == "production" {
 		return ("latest")
 	}
@@ -404,7 +404,7 @@ func imagePathGen(event transistor.Event) string {
 		log.Error(err)
 	}
 
-	payload := event.Payload().(plugins.ReleaseExtension)
+	payload := event.Payload.(plugins.ReleaseExtension)
 	return (fmt.Sprintf("%s/%s/%s", registryHost.String(), registryOrg.String(), slug.Slug(payload.Release.Project.Repository)))
 }
 

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -68,10 +68,8 @@ func (x *DockerBuilder) Stop() {
 
 func (x *DockerBuilder) Subscribe() []string {
 	return []string{
-		"plugins.ReleaseExtension:create:dockerbuilder",
-		"plugins.ReleaseExtension:update:dockerbuilder",
-		"plugins.ProjectExtension:create:dockerbuilder",
-		"plugins.ProjectExtension:update:dockerbuilder",
+		"dockerbuilder:create",
+		"dockerbuilder:update",
 	}
 }
 

--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -293,13 +293,13 @@ func (x *DockerBuilder) push(repoPath string, event transistor.Event, buildlog i
 }
 
 func (x *DockerBuilder) Process(e transistor.Event) error {
-	if e.Name == "dockerbuilder:create" {
+	if e.Event() == "dockerbuilder:create" {
 		ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Installation complete.")
 		x.events <- ev
 		return nil
 	}
 
-	if e.Name == "dockerbuilder:update" {
+	if e.Event() == "dockerbuilder:update" {
 		ev := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Update complete.")
 		x.events <- ev
 		return nil

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -74,7 +74,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 		},
 	}
 
-	ev := transistor.NewEvent(dockerBuildEvent, nil)
+	ev := transistor.NewEvent(plugins.GetAction("create"), plugins.GetState("waiting"), "TestDockerBuilder")
 	ev.AddArtifact("USER", "test", false)
 	ev.AddArtifact("PASSWORD", "test", false)
 	ev.AddArtifact("EMAIL", "test@checkr.com", false)
@@ -82,15 +82,15 @@ func (suite *TestSuite) TestDockerBuilder() {
 	ev.AddArtifact("ORG", "testorg", false)
 	suite.transistor.Events <- ev
 
-	e = suite.transistor.GetTestEvent("plugins.ReleaseExtension:status:dockerbuilder", 60)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 60)
 	payload := e.Payload.(plugins.ReleaseExtension)
-	assert.Equal(suite.T(), string(plugins.GetAction("status")), string(payload.Action))
-	assert.Equal(suite.T(), string(plugins.GetState("fetching")), string(payload.State))
+	assert.Equal(suite.T(), plugins.GetAction("status"), payload.Action)
+	assert.Equal(suite.T(), plugins.GetState("fetching"), payload.State)
 
 	e = suite.transistor.GetTestEvent("plugins.ReleaseExtension:status:dockerbuilder", 600)
 	payload = e.Payload.(plugins.ReleaseExtension)
-	assert.Equal(suite.T(), string(plugins.GetAction("status")), string(payload.Action))
-	assert.Equal(suite.T(), string(plugins.GetState("complete")), string(payload.State))
+	assert.Equal(suite.T(), plugins.GetAction("status"), payload.Action)
+	assert.Equal(suite.T(), plugins.GetState("complete"), payload.State)
 
 	image, err := e.GetArtifact("image")
 	if err != nil {

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
+	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -76,7 +77,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 	ev.AddArtifact("USER", "test", false)
 	ev.AddArtifact("PASSWORD", "test", false)
 	ev.AddArtifact("EMAIL", "test@checkr.com", false)
-	ev.AddArtifact("HOST", "registry-testing.checkrhq-dev.net:5000", false)
+	ev.AddArtifact("HOST", "0.0.0.0:5000", false)
 	ev.AddArtifact("ORG", "testorg", false)
 	suite.transistor.Events <- ev
 
@@ -88,12 +89,13 @@ func (suite *TestSuite) TestDockerBuilder() {
 	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), plugins.GetState("complete"), e.State)
 
+	spew.Dump(e)
 	image, err := e.GetArtifact("image")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	assert.Equal(suite.T(), image.String(), "registry-testing.checkrhq-dev.net:5000/testorg/checkr-deploy-test:4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9.testing")
+	assert.Equal(suite.T(), image.String(), "0.0.0.0:5000/testorg/checkr-deploy-test:4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9.testing")
 }
 
 func TestDockerBuilder(t *testing.T) {

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -83,7 +83,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 60)
 	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
-	assert.Equal(suite.T(), plugins.GetState("fetching"), e.State)
+	assert.Equal(suite.T(), plugins.GetState("running"), e.State)
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 600)
 	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -49,9 +49,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 	deploytestHash := "4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9"
 
 	dockerBuildEvent := plugins.ReleaseExtension{
-		Slug:   "dockerbuilder",
-		Action: plugins.GetAction("create"),
-		State:  plugins.GetState("waiting"),
+		Slug: "dockerbuilder",
 		Release: plugins.Release{
 			Project: plugins.Project{
 				Repository: "checkr/deploy-test",
@@ -74,7 +72,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 		},
 	}
 
-	ev := transistor.NewEvent(plugins.GetAction("create"), plugins.GetState("waiting"), "TestDockerBuilder")
+	ev := transistor.NewEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("create"), dockerBuildEvent)
 	ev.AddArtifact("USER", "test", false)
 	ev.AddArtifact("PASSWORD", "test", false)
 	ev.AddArtifact("EMAIL", "test@checkr.com", false)
@@ -83,14 +81,12 @@ func (suite *TestSuite) TestDockerBuilder() {
 	suite.transistor.Events <- ev
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 60)
-	payload := e.Payload.(plugins.ReleaseExtension)
-	assert.Equal(suite.T(), plugins.GetAction("status"), payload.Action)
-	assert.Equal(suite.T(), plugins.GetState("fetching"), payload.State)
+	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), plugins.GetState("fetching"), e.State)
 
-	e = suite.transistor.GetTestEvent("plugins.ReleaseExtension:status:dockerbuilder", 600)
-	payload = e.Payload.(plugins.ReleaseExtension)
-	assert.Equal(suite.T(), plugins.GetAction("status"), payload.Action)
-	assert.Equal(suite.T(), plugins.GetState("complete"), payload.State)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 600)
+	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), plugins.GetState("complete"), e.State)
 
 	image, err := e.GetArtifact("image")
 	if err != nil {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -24,8 +24,6 @@ func GetEventName(s string) transistor.EventName {
 		"route53",
 		"release",
 		"project",
-		"releaseextension",
-		"projectextension",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -22,6 +22,8 @@ func GetEventName(s string) transistor.EventName {
 		"heartbeat",
 		"dockerbuilder",
 		"route53",
+		"release",
+		"project",
 	}
 
 	for _, t := range eventNames {
@@ -222,6 +224,9 @@ type ReleaseExtension struct {
 	Project     Project `json:"project"`
 	Release     Release `json:"release"`
 	Environment string  `json:"environment"`
+
+	State  State             `json:"state"`
+	Action transistor.Action `json:"action"`
 }
 
 type ProjectExtension struct {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -156,9 +156,10 @@ type GitCommit struct {
 }
 
 type GitSync struct {
-	Project Project `json:"project"`
-	Git     Git     `json:"git"`
-	From    string  `json:"from"`
+	Project Project     `json:"project"`
+	Git     Git         `json:"git"`
+	From    string      `json:"from"`
+	Commits []GitCommit `json:"commits"`
 }
 
 type Feature struct {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -21,6 +21,7 @@ func GetEventName(s string) transistor.EventName {
 		"route53",
 		"release",
 		"project",
+		"websocket",
 	}
 
 	for _, t := range eventNames {
@@ -37,37 +38,6 @@ func GetEventName(s string) transistor.EventName {
 
 	log.Panic(errMsg)
 	return transistor.EventName("unknown")
-}
-
-type State string
-
-func GetState(s string) transistor.State {
-	states := []string{
-		"waiting",
-		"running",
-		"fetching",
-		"building",
-		"pushing",
-		"complete",
-		"failed",
-		"deleting",
-		"deleted",
-	}
-
-	for _, state := range states {
-		if s == state {
-			return transistor.State(state)
-		}
-	}
-
-	errMsg := fmt.Sprintf("State not found: '%s' ", s)
-	_, file, line, ok := runtime.Caller(1)
-	if ok {
-		errMsg += fmt.Sprintf("%s : ln %d", file, line)
-	}
-
-	log.Panic(errMsg)
-	return transistor.State("unknown")
 }
 
 type Type string
@@ -103,32 +73,6 @@ func GetType(s string) Type {
 
 	log.Panic(errMsg)
 	return Type("unknown")
-}
-
-func GetAction(s string) transistor.Action {
-	actions := []string{
-		"create",
-		"run",
-		"update",
-		"destroy",
-		"rollback",
-		"status",
-	}
-
-	for _, action := range actions {
-		if s == action {
-			return transistor.Action(action)
-		}
-	}
-
-	errMsg := fmt.Sprintf("Action not found: '%s' ", s)
-	_, file, line, ok := runtime.Caller(1)
-	if ok {
-		errMsg += fmt.Sprintf("%s : ln %d", file, line)
-	}
-
-	log.Panic(errMsg)
-	return transistor.Action("unknown")
 }
 
 type Git struct {
@@ -187,8 +131,9 @@ type Service struct {
 	Spec      ServiceSpec `json:"spec"`
 	Type      string      `json:"type"`
 
-	State  transistor.State  `json:"state"`
-	Action transistor.Action `json:"action"`
+	State        transistor.State  `json:"state"`
+	StateMessage string            `json:"stateMessage"`
+	Action       transistor.Action `json:"action"`
 }
 
 type ServiceSpec struct {
@@ -218,25 +163,19 @@ type WebsocketMsg struct {
 
 type ReleaseExtension struct {
 	ID          string  `json:"id"`
-	Slug        string  `json:"slug"`
 	Project     Project `json:"project"`
 	Release     Release `json:"release"`
 	Environment string  `json:"environment"`
-
-	State  transistor.State  `json:"state"`
-	Action transistor.Action `json:"action"`
 }
 
 type ProjectExtension struct {
 	ID          string  `json:"id"`
-	Slug        string  `json:"slug"`
 	Project     Project `json:"project"`
 	Environment string  `json:"environment"`
 }
 
 type Release struct {
-	ID string `json:"id"`
-
+	ID          string    `json:"id"`
 	Project     Project   `json:"project"`
 	Git         Git       `json:"git"`
 	HeadFeature Feature   `json:"headFeature"`

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -10,14 +10,6 @@ import (
 )
 
 func init() {
-	// transistor.RegisterEvent(Project{})
-	// transistor.RegisterEvent(GitCommit{})
-	// transistor.RegisterEvent(GitSync{})
-	// transistor.RegisterEvent(WebsocketMsg{})
-	// transistor.RegisterEvent(HeartBeat{})
-	// transistor.RegisterEvent(Release{})
-	// transistor.RegisterEvent(ProjectExtension{})
-	// transistor.RegisterEvent(ReleaseExtension{})
 }
 
 func GetEventName(s string) transistor.EventName {
@@ -25,6 +17,8 @@ func GetEventName(s string) transistor.EventName {
 		"kubernetes:deployment",
 		"kubernetes:loadbalancer",
 		"githubstatus",
+		"gitsync",
+		"gitsync:commit",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -23,6 +23,7 @@ func GetEventName(s string) transistor.EventName {
 		"dockerbuilder",
 		"route53",
 		"release",
+		"project",
 		"releaseextension",
 		"projectextension",
 	}
@@ -226,7 +227,7 @@ type ReleaseExtension struct {
 	Release     Release `json:"release"`
 	Environment string  `json:"environment"`
 
-	State  State             `json:"state"`
+	State  transistor.State  `json:"state"`
 	Action transistor.Action `json:"action"`
 }
 

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -9,9 +9,6 @@ import (
 	"github.com/codeamp/transistor"
 )
 
-func init() {
-}
-
 func GetEventName(s string) transistor.EventName {
 	eventNames := []string{
 		"kubernetes:deployment",

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -24,6 +24,7 @@ func GetEventName(s string) transistor.EventName {
 	eventNames := []string{
 		"kubernetes:deployment",
 		"kubernetes:loadbalancer",
+		"githubstatus",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -20,6 +20,7 @@ func GetEventName(s string) transistor.EventName {
 		"gitsync",
 		"gitsync:commit",
 		"heartbeat",
+		"dockerbuilder",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -23,7 +23,8 @@ func GetEventName(s string) transistor.EventName {
 		"dockerbuilder",
 		"route53",
 		"release",
-		"project",
+		"releaseextension",
+		"projectextension",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -21,6 +21,7 @@ func GetEventName(s string) transistor.EventName {
 		"gitsync:commit",
 		"heartbeat",
 		"dockerbuilder",
+		"route53",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"fmt"
+	"runtime"
 	"time"
 
 	log "github.com/codeamp/logger"
@@ -9,19 +10,41 @@ import (
 )
 
 func init() {
-	transistor.RegisterEvent(Project{})
-	transistor.RegisterEvent(GitCommit{})
-	transistor.RegisterEvent(GitSync{})
-	transistor.RegisterEvent(WebsocketMsg{})
-	transistor.RegisterEvent(HeartBeat{})
-	transistor.RegisterEvent(Release{})
-	transistor.RegisterEvent(ProjectExtension{})
-	transistor.RegisterEvent(ReleaseExtension{})
+	// transistor.RegisterEvent(Project{})
+	// transistor.RegisterEvent(GitCommit{})
+	// transistor.RegisterEvent(GitSync{})
+	// transistor.RegisterEvent(WebsocketMsg{})
+	// transistor.RegisterEvent(HeartBeat{})
+	// transistor.RegisterEvent(Release{})
+	// transistor.RegisterEvent(ProjectExtension{})
+	// transistor.RegisterEvent(ReleaseExtension{})
+}
+
+func GetEventName(s string) transistor.EventName {
+	eventNames := []string{
+		"kubernetes:deployment",
+		"kubernetes:loadbalancer",
+	}
+
+	for _, t := range eventNames {
+		if s == t {
+			return transistor.EventName(t)
+		}
+	}
+
+	errMsg := fmt.Sprintf("EventName not found: '%s' ", s)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		errMsg += fmt.Sprintf("%s : ln %d", file, line)
+	}
+
+	log.Panic(errMsg)
+	return transistor.EventName("unknown")
 }
 
 type State string
 
-func GetState(s string) State {
+func GetState(s string) transistor.State {
 	states := []string{
 		"waiting",
 		"running",
@@ -36,13 +59,18 @@ func GetState(s string) State {
 
 	for _, state := range states {
 		if s == state {
-			return State(state)
+			return transistor.State(state)
 		}
 	}
 
-	log.Info(fmt.Sprintf("State not found: %s", s))
+	errMsg := fmt.Sprintf("State not found: '%s' ", s)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		errMsg += fmt.Sprintf("%s : ln %d", file, line)
+	}
 
-	return State("unknown")
+	log.Panic(errMsg)
+	return transistor.State("unknown")
 }
 
 type Type string
@@ -70,14 +98,17 @@ func GetType(s string) Type {
 		}
 	}
 
-	log.Info(fmt.Sprintf("Type not found: %s", s))
+	errMsg := fmt.Sprintf("Type not found: '%s' ", s)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		errMsg += fmt.Sprintf("%s : ln %d", file, line)
+	}
 
+	log.Panic(errMsg)
 	return Type("unknown")
 }
 
-type Action string
-
-func GetAction(s string) Action {
+func GetAction(s string) transistor.Action {
 	actions := []string{
 		"create",
 		"run",
@@ -89,13 +120,18 @@ func GetAction(s string) Action {
 
 	for _, action := range actions {
 		if s == action {
-			return Action(action)
+			return transistor.Action(action)
 		}
 	}
 
-	log.Info(fmt.Sprintf("Action not found: %s", s))
+	errMsg := fmt.Sprintf("Action not found: '%s' ", s)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		errMsg += fmt.Sprintf("%s : ln %d", file, line)
+	}
 
-	return Action("unknown")
+	log.Panic(errMsg)
+	return transistor.Action("unknown")
 }
 
 type Git struct {
@@ -120,12 +156,9 @@ type GitCommit struct {
 }
 
 type GitSync struct {
-	Action       Action  `json:"action"`
-	State        State   `json:"state"`
-	StateMessage string  `json:"stateMessage"`
-	Project      Project `json:"project"`
-	Git          Git     `json:"git"`
-	From         string  `json:"from"`
+	Project Project `json:"project"`
+	Git     Git     `json:"git"`
+	From    string  `json:"from"`
 }
 
 type Feature struct {
@@ -148,16 +181,16 @@ type ListenerPair struct {
 }
 
 type Service struct {
-	ID           string      `json:"id"`
-	Action       Action      `json:"action"`
-	Name         string      `json:"name"`
-	Command      string      `json:"command"`
-	Listeners    []Listener  `json:"listeners"`
-	Replicas     int64       `json:"replicas"`
-	State        State       `json:"state"`
-	StateMessage string      `json:"stateMessage"`
-	Spec         ServiceSpec `json:"spec"`
-	Type         string      `json:"type"`
+	ID        string      `json:"id"`
+	Name      string      `json:"name"`
+	Command   string      `json:"command"`
+	Listeners []Listener  `json:"listeners"`
+	Replicas  int64       `json:"replicas"`
+	Spec      ServiceSpec `json:"spec"`
+	Type      string      `json:"type"`
+
+	State  transistor.State  `json:"state"`
+	Action transistor.Action `json:"action"`
 }
 
 type ServiceSpec struct {
@@ -186,39 +219,31 @@ type WebsocketMsg struct {
 }
 
 type ReleaseExtension struct {
-	ID           string  `json:"id"`
-	Action       Action  `json:"action"`
-	Slug         string  `json:"slug"`
-	State        State   `json:"state"`
-	StateMessage string  `json:"stateMessage"`
-	Project      Project `json:"project"`
-	Release      Release `json:"release"`
-	Environment  string  `json:"environment"`
+	ID          string  `json:"id"`
+	Slug        string  `json:"slug"`
+	Project     Project `json:"project"`
+	Release     Release `json:"release"`
+	Environment string  `json:"environment"`
 }
 
 type ProjectExtension struct {
-	ID           string  `json:"id"`
-	Action       Action  `json:"action"`
-	Slug         string  `json:"slug"`
-	State        State   `json:"state"`
-	StateMessage string  `json:"stateMessage"`
-	Project      Project `json:"project"`
-	Environment  string  `json:"environment"`
+	ID          string  `json:"id"`
+	Slug        string  `json:"slug"`
+	Project     Project `json:"project"`
+	Environment string  `json:"environment"`
 }
 
 type Release struct {
-	ID           string    `json:"id"`
-	Action       Action    `json:"action"`
-	State        State     `json:"state"`
-	StateMessage string    `json:"stateMessage"`
-	Project      Project   `json:"project"`
-	Git          Git       `json:"git"`
-	HeadFeature  Feature   `json:"headFeature"`
-	User         string    `json:"user"`
-	TailFeature  Feature   `json:"tailFeature"`
-	Services     []Service `json:"services"`
-	Secrets      []Secret  `json:"secrets" role:"secret"`
-	Environment  string    `json:"environment"`
+	ID string `json:"id"`
+
+	Project     Project   `json:"project"`
+	Git         Git       `json:"git"`
+	HeadFeature Feature   `json:"headFeature"`
+	User        string    `json:"user"`
+	TailFeature Feature   `json:"tailFeature"`
+	Services    []Service `json:"services"`
+	Secrets     []Secret  `json:"secrets" role:"secret"`
+	Environment string    `json:"environment"`
 }
 
 type Project struct {

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -19,6 +19,7 @@ func GetEventName(s string) transistor.EventName {
 		"githubstatus",
 		"gitsync",
 		"gitsync:commit",
+		"heartbeat",
 	}
 
 	for _, t := range eventNames {

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -93,7 +93,7 @@ func getStatus(e transistor.Event) (StatusResponse, error) {
 		return StatusResponse{}, err
 	}
 
-	payload := e.Payload().(plugins.ReleaseExtension)
+	payload := e.Payload.(plugins.ReleaseExtension)
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", payload.Release.Project.Repository, payload.Release.HeadFeature.Hash), nil)
 	if err != nil {
 		return StatusResponse{}, err
@@ -163,7 +163,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		return err
 	}
 
-	if e.PayloadModel() == "plugins.ProjectExtension" {
+	if e.PayloadModel == "plugins.ProjectExtension" {
 		switch e.Action {
 		case plugins.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
@@ -189,8 +189,8 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		}
 	}
 
-	if e.PayloadModel() == "plugins.ReleaseExtension" {
-		payload := e.Payload().(plugins.ReleaseExtension)
+	if e.PayloadModel == "plugins.ReleaseExtension" {
+		payload := e.Payload.(plugins.ReleaseExtension)
 
 		switch e.Action {
 		case plugins.GetAction("create"):

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -22,7 +22,7 @@ type GithubStatus struct {
 func init() {
 	transistor.RegisterPlugin("githubstatus", func() transistor.Plugin {
 		return &GithubStatus{}
-	})
+	}, plugins.ReleaseExtension{})
 }
 
 func (x *GithubStatus) Description() string {

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -346,9 +346,9 @@ func (x *GithubStatus) createProjectExtension(e transistor.Event, username trans
 	var event transistor.Event
 >>>>>>> WIP on GithubStatus
 	if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully installed!")
+		event = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully installed!")
 	} else {
-		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
+		event = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 	}
 
 	x.events <- event

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -191,7 +191,8 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 
 	if e.PayloadModel() == "plugins.ReleaseExtension" {
 		payload := e.Payload().(plugins.ReleaseExtension)
-		switch payload.Action {
+
+		switch e.Action {
 		case plugins.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{
 				"hash": payload.Release.HeadFeature.Hash,
@@ -218,7 +219,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 
 				if status.State == "success" {
 					breakTheLoop = true
-					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("status"), "All status checks successful.")
+					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "All status checks successful.")
 				} else if status.State == "failure" {
 					breakTheLoop = true
 					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), "One or more status checks failed.")

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -47,7 +47,7 @@ func (x *GithubStatus) Subscribe() []string {
 	return []string{
 		"githubstatus:create",
 		"githubstatus:update",
-		"githubstatus:destroy",
+		"githubstatus:delete",
 	}
 }
 
@@ -165,22 +165,22 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 
 	if e.PayloadModel == "plugins.ProjectExtension" {
 		switch e.Action {
-		case plugins.GetAction("create"):
+		case transistor.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
 			if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully installed!")
+				x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Successfully installed!")
 				return nil
 			} else {
-				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
+				x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), err.Error())
 				return nil
 			}
-		case plugins.GetAction("update"):
+		case transistor.GetAction("update"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
 			if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully updated!")
+				x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Successfully updated!")
 				return nil
 			} else {
-				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
+				x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), err.Error())
 				return nil
 			}
 		default:
@@ -193,7 +193,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		payload := e.Payload.(plugins.ReleaseExtension)
 
 		switch e.Action {
-		case plugins.GetAction("create"):
+		case transistor.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{
 				"hash": payload.Release.HeadFeature.Hash,
 			})
@@ -213,22 +213,22 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 						"hash": payload.Release.HeadFeature.Hash,
 					})
 
-					x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
+					x.events <- e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), err.Error())
 					return nil
 				}
 
 				if status.State == "success" {
 					breakTheLoop = true
-					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "All status checks successful.")
+					evt = e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "All status checks successful.")
 				} else if status.State == "failure" {
 					breakTheLoop = true
-					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), "One or more status checks failed.")
+					evt = e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), "One or more status checks failed.")
 				} else if timeout >= timeoutLimitInt {
 					breakTheLoop = true
-					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%d seconds timeout reached", timeoutLimitInt))
+					evt = e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), fmt.Sprintf("%d seconds timeout reached", timeoutLimitInt))
 				} else {
 					breakTheLoop = false
-					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("running"), "One or more status checks are running.")
+					evt = e.NewEvent(transistor.GetAction("status"), transistor.GetState("running"), "One or more status checks are running.")
 				}
 
 				// Collect artifacts

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -313,8 +313,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 }
 
 func (x *GithubStatus) reportFailureEvent(e transistor.Event, err error) {
-	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
-	event.SetState(plugins.GetState("failed"), err.Error())
+	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 	x.events <- event
 }
 
@@ -335,16 +334,21 @@ func isValidGithubCredentials(username string, token string) (bool, error) {
 
 func (x *GithubStatus) createProjectExtension(e transistor.Event, username transistor.Artifact, token transistor.Artifact) error {
 <<<<<<< HEAD
+<<<<<<< HEAD
 	log.InfoWithFields(fmt.Sprintf("Process GithubStatus project extension event: %s", e.Event()), log.Fields{})
 
 	event := e.NewEvent(plugins.GetEventName("githubstatus"), plugins.GetAction("status"), e.Payload)
 =======
 	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
 >>>>>>> WIP on Event Refactor
+=======
+
+	var event transistor.Event
+>>>>>>> WIP on GithubStatus
 	if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-		event.SetState(plugins.GetState("complete"), "Successfully installed!")
+		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully installed!")
 	} else {
-		event.SetState(plugins.GetState("failed"), err.Error())
+		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 	}
 
 	x.events <- event
@@ -352,11 +356,11 @@ func (x *GithubStatus) createProjectExtension(e transistor.Event, username trans
 }
 
 func (x *GithubStatus) updateProjectExtension(e transistor.Event, username transistor.Artifact, token transistor.Artifact) error {
-	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
+	var event transistor.Event
 	if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-		event.SetState(plugins.GetState("complete"), "Successfully updated!")
+		event = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully updated!")
 	} else {
-		event.SetState(plugins.GetState("failed"), err.Error())
+		event = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 	}
 
 	x.events <- event
@@ -526,13 +530,13 @@ func (x *GithubStatus) createReleaseExtension(e transistor.Event, username trans
 		log.Debug("Looping through again and checking statuses")
 =======
 
-			evt := e.NewEvent(plugins.GetAction("status"), payload)
+			var evt transistor.Event
 			if status.State == "success" {
-				evt.SetState(plugins.GetState("complete"), "All status checks successful.")
+				evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "All status checks successful.")
 			} else if status.State == "failure" {
-				evt.SetState(plugins.GetState("failed"), "One or more status checks failed.")
+				evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), "One or more status checks failed.")
 			} else {
-				evt.SetState(plugins.GetState("running"), "One or more status checks are running.")
+				evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("running"), "One or more status checks are running.")
 			}
 
 			for _, _status := range status.Statuses {

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -45,9 +45,10 @@ func (x *GithubStatus) Stop() {
 
 func (x *GithubStatus) Subscribe() []string {
 	return []string{
-		"githubstatus:create",
-		"githubstatus:update",
-		"githubstatus:delete",
+		"project:githubstatus:create",
+		"project:githubstatus:update",
+		"project:githubstatus:delete",
+		"release:githubstatus:create",
 	}
 }
 
@@ -163,7 +164,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		return err
 	}
 
-	if e.PayloadModel == "plugins.ProjectExtension" {
+	if e.Matches("project:githubstatus") {
 		switch e.Action {
 		case transistor.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
@@ -189,7 +190,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		}
 	}
 
-	if e.PayloadModel == "plugins.ReleaseExtension" {
+	if e.Matches("release:githubstatus") {
 		payload := e.Payload.(plugins.ReleaseExtension)
 
 		switch e.Action {

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -48,8 +48,6 @@ func (x *GithubStatus) Subscribe() []string {
 		"githubstatus:create",
 		"githubstatus:update",
 		"githubstatus:destroy",
-		"projectextension",
-		"releaseextension",
 	}
 }
 
@@ -165,7 +163,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		return err
 	}
 
-	if e.Matches("projectextension") {
+	if e.PayloadModel == "plugins.ProjectExtension" {
 		switch e.Action {
 		case plugins.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
@@ -191,7 +189,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		}
 	}
 
-	if e.Matches("releaseextension") {
+	if e.PayloadModel == "plugins.ReleaseExtension" {
 		payload := e.Payload.(plugins.ReleaseExtension)
 		switch payload.Action {
 		case plugins.GetAction("create"):

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -93,7 +93,7 @@ func getStatus(e transistor.Event) (StatusResponse, error) {
 		return StatusResponse{}, err
 	}
 
-	payload := e.Payload.(plugins.ReleaseExtension)
+	payload := e.Payload().(plugins.ReleaseExtension)
 	req, err := http.NewRequest("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", payload.Release.Project.Repository, payload.Release.HeadFeature.Hash), nil)
 	if err != nil {
 		return StatusResponse{}, err
@@ -163,7 +163,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		return err
 	}
 
-	if e.PayloadModel == "plugins.ProjectExtension" {
+	if e.PayloadModel() == "plugins.ProjectExtension" {
 		switch e.Action {
 		case plugins.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
@@ -189,8 +189,8 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		}
 	}
 
-	if e.PayloadModel == "plugins.ReleaseExtension" {
-		payload := e.Payload.(plugins.ReleaseExtension)
+	if e.PayloadModel() == "plugins.ReleaseExtension" {
+		payload := e.Payload().(plugins.ReleaseExtension)
 		switch payload.Action {
 		case plugins.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{

--- a/plugins/githubstatus/githubstatus.go
+++ b/plugins/githubstatus/githubstatus.go
@@ -35,19 +35,21 @@ func (x *GithubStatus) SampleConfig() string {
 
 func (x *GithubStatus) Start(e chan transistor.Event) error {
 	x.events = e
-	log.Println("Started GithubStatus")
+	log.Info("Started GithubStatus")
 	return nil
 }
 
 func (x *GithubStatus) Stop() {
-	log.Println("Stopping GithubStatus")
+	log.Info("Stopping GithubStatus")
 }
 
 func (x *GithubStatus) Subscribe() []string {
 	return []string{
-		"plugins.ProjectExtension:create:githubstatus",
-		"plugins.ProjectExtension:update:githubstatus",
-		"plugins.ReleaseExtension:create:githubstatus",
+		"githubstatus:create",
+		"githubstatus:update",
+		"githubstatus:destroy",
+		"projectextension",
+		"releaseextension",
 	}
 }
 
@@ -131,7 +133,7 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 	timeoutInterval := 5
 	userTimeoutInterval, err := e.GetArtifact("timeout_interval")
 	if err != nil {
-		log.Debug(err.Error())
+		log.Error(err.Error())
 	} else {
 		timeoutInterval, err = strconv.Atoi(userTimeoutInterval.String())
 		if err != nil {
@@ -163,55 +165,37 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 		return err
 	}
 
-	if e.Matches("plugins.ProjectExtension") {
-		event := e.Payload.(plugins.ProjectExtension)
-
-		switch event.Action {
+	if e.Matches("projectextension") {
+		switch e.Action {
 		case plugins.GetAction("create"):
-			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Name), log.Fields{})
+			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
 			if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-				responseEvent := e.Payload.(plugins.ProjectExtension)
-				responseEvent.State = plugins.GetState("complete")
-				responseEvent.Action = plugins.GetAction("status")
-				responseEvent.StateMessage = "Successfully installed!"
-				x.events <- e.NewEvent(responseEvent, nil)
+				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully installed!")
 				return nil
 			} else {
-				failedEvent := e.Payload.(plugins.ProjectExtension)
-				failedEvent.State = plugins.GetState("failed")
-				failedEvent.Action = plugins.GetAction("status")
-				failedEvent.StateMessage = err.Error()
-				x.events <- e.NewEvent(failedEvent, err)
+				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 				return nil
 			}
 		case plugins.GetAction("update"):
-			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Name), log.Fields{})
+			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{})
 			if _, err := isValidGithubCredentials(username.String(), token.String()); err == nil {
-				responseEvent := e.Payload.(plugins.ProjectExtension)
-				responseEvent.State = plugins.GetState("complete")
-				responseEvent.Action = plugins.GetAction("status")
-				responseEvent.StateMessage = "Successfully updated!"
-				x.events <- e.NewEvent(responseEvent, nil)
+				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Successfully updated!")
 				return nil
 			} else {
-				failedEvent := e.Payload.(plugins.ProjectExtension)
-				failedEvent.State = plugins.GetState("failed")
-				failedEvent.Action = plugins.GetAction("status")
-				failedEvent.StateMessage = err.Error()
-				x.events <- e.NewEvent(failedEvent, err)
+				x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 				return nil
 			}
 		default:
-			log.InfoWithFields(fmt.Sprintf("GithubStatus ProjectExtension event not handled: %s", e.Name), log.Fields{})
+			log.WarnWithFields(fmt.Sprintf("GithubStatus ProjectExtension event not handled: %s", e.Event()), log.Fields{})
 			return nil
 		}
 	}
 
-	if e.Matches("plugins.ReleaseExtension") {
+	if e.Matches("releaseextension") {
 		payload := e.Payload.(plugins.ReleaseExtension)
 		switch payload.Action {
 		case plugins.GetAction("create"):
-			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Name), log.Fields{
+			log.InfoWithFields(fmt.Sprintf("Process GithubStatus event: %s", e.Event()), log.Fields{
 				"hash": payload.Release.HeadFeature.Hash,
 			})
 
@@ -230,38 +214,22 @@ func (x *GithubStatus) Process(e transistor.Event) error {
 						"hash": payload.Release.HeadFeature.Hash,
 					})
 
-					payload.State = plugins.GetState("failed")
-					payload.Action = plugins.GetAction("status")
-					payload.StateMessage = err.Error()
-					evt = e.NewEvent(payload, nil)
-					x.events <- e.NewEvent(payload, err)
+					x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), err.Error())
 					return nil
 				}
 
 				if status.State == "success" {
 					breakTheLoop = true
-					payload.State = plugins.GetState("complete")
-					payload.Action = plugins.GetAction("status")
-					payload.StateMessage = "All status checks successful."
-					evt = e.NewEvent(payload, nil)
+					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("status"), "All status checks successful.")
 				} else if status.State == "failure" {
 					breakTheLoop = true
-					payload.State = plugins.GetState("failed")
-					payload.Action = plugins.GetAction("status")
-					payload.StateMessage = "One or more status checks failed."
-					evt = e.NewEvent(payload, nil)
+					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), "One or more status checks failed.")
 				} else if timeout >= timeoutLimitInt {
 					breakTheLoop = true
-					payload.State = plugins.GetState("failed")
-					payload.Action = plugins.GetAction("status")
-					payload.StateMessage = fmt.Sprintf("%d seconds timeout reached", timeoutLimitInt)
-					evt = e.NewEvent(payload, nil)
+					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%d seconds timeout reached", timeoutLimitInt))
 				} else {
 					breakTheLoop = false
-					payload.State = plugins.GetState("running")
-					payload.Action = plugins.GetAction("status")
-					payload.StateMessage = "One or more status checks are running."
-					evt = e.NewEvent(payload, nil)
+					evt = e.NewEvent(plugins.GetAction("status"), plugins.GetState("running"), "One or more status checks are running.")
 				}
 
 				// Collect artifacts

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -158,12 +158,9 @@ func (suite *TestSuite) TestGithubStatus() {
 
 	suite.transistor.Events <- ev
 
-	for {
-		e = suite.transistor.GetTestEvent(plugins.GetEventName("githubstatus"), plugins.GetAction("status"), 15)
-		if e.State != "running" {
-			break
-		}
-	}
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("githubstatus"), plugins.GetAction("status"), 10)
+	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), plugins.GetState("running"), e.State)
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusPayload.Release.Project.Repository, githubStatusPayload.Release.HeadFeature.Hash),
 		httpmock.NewStringResponder(200, githubSuccessStatusResponse))

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -2,17 +2,19 @@ package githubstatus_test
 
 import (
 	"bytes"
-	"testing"
 	"fmt"
+	"testing"
+	"time"
 
 	"github.com/codeamp/circuit/plugins"
+	"github.com/codeamp/circuit/plugins/githubstatus"
 	log "github.com/codeamp/logger"
-	httpmock "gopkg.in/jarcoal/httpmock.v1"
 	"github.com/codeamp/transistor"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	httpmock "gopkg.in/jarcoal/httpmock.v1"
 )
 
 type TestSuite struct {
@@ -35,6 +37,10 @@ func (suite *TestSuite) SetupSuite() {
 		EnabledPlugins: []string{"githubstatus"},
 	}
 
+	transistor.RegisterPlugin("githubstatus", func() transistor.Plugin {
+		return &githubstatus.GithubStatus{}
+	})
+
 	ag, _ := transistor.NewTestTransistor(config)
 	suite.transistor = ag
 	go suite.transistor.Run()
@@ -45,6 +51,14 @@ func (suite *TestSuite) TearDownSuite() {
 }
 
 func (suite *TestSuite) TestGithubStatus() {
+	timer := time.NewTimer(time.Second * 120)
+	defer timer.Stop()
+
+	go func() {
+		<-timer.C
+		log.Fatal("TestGithubStatus: Test timeout")
+	}()
+
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
@@ -53,11 +67,8 @@ func (suite *TestSuite) TestGithubStatus() {
 	var e transistor.Event
 	log.SetLogLevel(logrus.DebugLevel)
 
-
-	githubStatusEvent := plugins.ReleaseExtension{
-		Slug:   "githubstatus",
-		Action: plugins.GetAction("create"),
-		State:  plugins.GetState("waiting"),
+	githubStatusPayload := plugins.ReleaseExtension{
+		Slug: "githubstatus",
 		Release: plugins.Release{
 			Project: plugins.Project{
 				Repository: "checkr/deploy-test",
@@ -136,27 +147,30 @@ func (suite *TestSuite) TestGithubStatus() {
 	}	
 	`
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusEvent.Release.Project.Repository, githubStatusEvent.Release.HeadFeature.Hash),
-		httpmock.NewStringResponder(200, githubRunningStatusResponse))	
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusPayload.Release.Project.Repository, githubStatusPayload.Release.HeadFeature.Hash),
+		httpmock.NewStringResponder(200, githubRunningStatusResponse))
 
-	ev := transistor.NewEvent(githubStatusEvent, nil)
+	ev := transistor.NewEvent(plugins.GetEventName("githubstatus"), plugins.GetAction("create"), githubStatusPayload)
 	ev.AddArtifact("timeout_seconds", "100", false)
+	ev.AddArtifact("timeout_interval", "5", false)
 	ev.AddArtifact("personal_access_token", "test", false)
 	ev.AddArtifact("username", "test", false)
 
 	suite.transistor.Events <- ev
-	e = suite.transistor.GetTestEvent("plugins.ReleaseExtension:status:githubstatus", 60)
-	payload := e.Payload.(plugins.ReleaseExtension)
-	assert.Equal(suite.T(), string(plugins.GetAction("status")), string(payload.Action))
-	assert.Equal(suite.T(), string(plugins.GetState("running")), string(payload.State))
 
-	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusEvent.Release.Project.Repository, githubStatusEvent.Release.HeadFeature.Hash),
-		httpmock.NewStringResponder(200, githubSuccessStatusResponse))		
+	for {
+		e = suite.transistor.GetTestEvent(plugins.GetEventName("githubstatus"), plugins.GetAction("status"), 15)
+		if e.State != "running" {
+			break
+		}
+	}
 
-	e = suite.transistor.GetTestEvent("plugins.ReleaseExtension:status:githubstatus", 60)
-	payload = e.Payload.(plugins.ReleaseExtension)	
-	assert.Equal(suite.T(), string(plugins.GetAction("status")), string(payload.Action))
-	assert.Equal(suite.T(), string(plugins.GetState("complete")), string(payload.State))
+	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusPayload.Release.Project.Repository, githubStatusPayload.Release.HeadFeature.Hash),
+		httpmock.NewStringResponder(200, githubSuccessStatusResponse))
+
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("githubstatus"), plugins.GetAction("status"), 10)
+	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), plugins.GetState("complete"), e.State)
 }
 
 func TestDockerBuilder(t *testing.T) {

--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -220,14 +220,14 @@ func (x *GitSync) Process(e transistor.Event) error {
 
 	if e.Event() == "gitsync:create" {
 		payload := e.Payload.(plugins.GitSync)
-		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("fetching"), "Fetching resource")
+		event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("running"), "Fetching resource")
 		x.events <- event
 
 		commits, err := x.commits(payload.Project, payload.Git)
 		if err != nil {
 			log.Error(err)
 
-			errEvent := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%v (Action: %v)", err.Error(), "failed"))
+			errEvent := e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), fmt.Sprintf("%v (Action: %v)", err.Error(), "failed"))
 			x.events <- errEvent
 
 			return err
@@ -248,7 +248,7 @@ func (x *GitSync) Process(e transistor.Event) error {
 
 		payload.Commits = _commits
 
-		event = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Operation Complete")
+		event = e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), "Operation Complete")
 		event.SetPayload(payload)
 
 		x.events <- event

--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -65,8 +65,8 @@ func (x *GitSync) Stop() {
 
 func (x *GitSync) Subscribe() []string {
 	return []string{
-		"gitsync:update",
 		"gitsync:create",
+		"gitsync:update",
 	}
 }
 
@@ -254,6 +254,10 @@ func (x *GitSync) Process(e transistor.Event) error {
 
 		event = e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), "Operation Complete")
 		x.events <- event
+	}
+
+	if e.Event() == "gitsync:update" {
+		log.WarnWithFields("Event received by githubsync yet unhandled!", log.Fields{"event": e})
 	}
 
 	return nil

--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -219,7 +219,7 @@ func (x *GitSync) Process(e transistor.Event) error {
 	})
 
 	if e.Event() == "gitsync:create" {
-		payload := e.Payload().(plugins.GitSync)
+		payload := e.Payload.(plugins.GitSync)
 		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("fetching"), "Fetching resource")
 		x.events <- event
 

--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -25,7 +25,7 @@ type GitSync struct {
 func init() {
 	transistor.RegisterPlugin("gitsync", func() transistor.Plugin {
 		return &GitSync{}
-	})
+	}, plugins.GitSync{})
 }
 
 func (x *GitSync) Description() string {

--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -219,7 +219,7 @@ func (x *GitSync) Process(e transistor.Event) error {
 	})
 
 	if e.Event() == "gitsync:create" {
-		payload := e.Payload.(plugins.GitSync)
+		payload := e.Payload().(plugins.GitSync)
 		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("fetching"), "Fetching resource")
 		x.events <- event
 
@@ -248,7 +248,7 @@ func (x *GitSync) Process(e transistor.Event) error {
 			}
 
 			event = transistor.NewEvent(plugins.GetEventName("gitsync:commit"), plugins.GetAction("create"), c.Ref)
-			event.OverridePayload(c)
+			event.SetPayload(c)
 			x.events <- event
 		}
 

--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -47,8 +47,6 @@ func (x *GitSync) Start(e chan transistor.Event) error {
 
 	// create global gitconfig file
 	gitconfigPath := fmt.Sprintf("%s/.gitconfig", usr.HomeDir)
-	log.Info(gitconfigPath)
-
 	if _, err := os.Stat(gitconfigPath); os.IsNotExist(err) {
 		log.Warn("Local .gitconfig file not found! Writing default.")
 		err = ioutil.WriteFile(gitconfigPath, []byte("[user]\n  name = codeamp \n  email = codeamp@codeamp.com"), 0600)

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -3,11 +3,9 @@ package gitsync_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/gitsync"
-	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -69,23 +67,12 @@ func (suite *TestSuite) TestGitSync() {
 	suite.transistor.Events <- event
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), plugins.GetAction("status"), 30)
-	log.Info("fetching")
 	assert.Equal(suite.T(), e.State, plugins.GetState("fetching"))
 
-	created := time.Now()
-	for i := 0; i < 5; i++ {
-		e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync:commit"), plugins.GetAction("create"), 60)
-		payload := e.Payload().(plugins.GitCommit)
-
-		log.Info(payload)
-
-		// assert.Equal(suite.T(), payload.Repository, payload.Project.Repository)
-		// assert.Equal(suite.T(), payload.Ref, fmt.Sprintf("refs/heads/%s", payload.Git.Branch))
-		assert.True(suite.T(), payload.Created.Before(created), "Commit created time is older than previous commit")
-	}
-
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), plugins.GetAction("status"), 60)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), plugins.GetAction("status"), 30)
 	assert.Equal(suite.T(), e.State, plugins.GetState("complete"))
+	assert.NotNil(suite.T(), e.Payload().(plugins.GitSync).Commits)
+	assert.NotEqual(suite.T(), 0, len(e.Payload().(plugins.GitSync).Commits), "commits should not be empty")
 }
 
 func TestGitSync(t *testing.T) {

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -71,8 +71,8 @@ func (suite *TestSuite) TestGitSync() {
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), plugins.GetAction("status"), 30)
 	assert.Equal(suite.T(), e.State, plugins.GetState("complete"))
-	assert.NotNil(suite.T(), e.Payload().(plugins.GitSync).Commits)
-	assert.NotEqual(suite.T(), 0, len(e.Payload().(plugins.GitSync).Commits), "commits should not be empty")
+	assert.NotNil(suite.T(), e.Payload.(plugins.GitSync).Commits)
+	assert.NotEqual(suite.T(), 0, len(e.Payload.(plugins.GitSync).Commits), "commits should not be empty")
 }
 
 func TestGitSync(t *testing.T) {

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -75,7 +75,7 @@ func (suite *TestSuite) TestGitSync() {
 	created := time.Now()
 	for i := 0; i < 5; i++ {
 		e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync:commit"), plugins.GetAction("create"), 60)
-		payload := e.Payload.(plugins.GitCommit)
+		payload := e.Payload().(plugins.GitCommit)
 
 		log.Info(payload)
 

--- a/plugins/heartbeat/heartbeat.go
+++ b/plugins/heartbeat/heartbeat.go
@@ -23,22 +23,21 @@ func (x *Heartbeat) Start(e chan transistor.Event) error {
 	x.events = e
 
 	cron.NewCronJob(cron.ANY, cron.ANY, cron.ANY, cron.ANY, cron.ANY, 0, func(time.Time) {
-		event := transistor.NewEvent(plugins.HeartBeat{Tick: "minute"}, nil)
+		event := transistor.NewEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), plugins.HeartBeat{Tick: "minute"})
 		x.events <- event
 	})
 
 	cron.NewCronJob(cron.ANY, cron.ANY, cron.ANY, cron.ANY, 0, 0, func(time.Time) {
-		event := transistor.NewEvent(plugins.HeartBeat{Tick: "hour"}, nil)
+		event := transistor.NewEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), plugins.HeartBeat{Tick: "hour"})
 		x.events <- event
 	})
 
-	log.Println("Started Heartbeat")
-
+	log.Info("Started Heartbeat")
 	return nil
 }
 
 func (x *Heartbeat) Stop() {
-	log.Println("Stopping Heartbeat")
+	log.Info("Stopping Heartbeat")
 }
 
 func (x *Heartbeat) Subscribe() []string {

--- a/plugins/heartbeat/heartbeat.go
+++ b/plugins/heartbeat/heartbeat.go
@@ -23,12 +23,12 @@ func (x *Heartbeat) Start(e chan transistor.Event) error {
 	x.events = e
 
 	cron.NewCronJob(cron.ANY, cron.ANY, cron.ANY, cron.ANY, cron.ANY, 0, func(time.Time) {
-		event := transistor.NewEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), plugins.HeartBeat{Tick: "minute"})
+		event := transistor.NewEvent(plugins.GetEventName("heartbeat"), transistor.GetAction("status"), plugins.HeartBeat{Tick: "minute"})
 		x.events <- event
 	})
 
 	cron.NewCronJob(cron.ANY, cron.ANY, cron.ANY, cron.ANY, 0, 0, func(time.Time) {
-		event := transistor.NewEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), plugins.HeartBeat{Tick: "hour"})
+		event := transistor.NewEvent(plugins.GetEventName("heartbeat"), transistor.GetAction("status"), plugins.HeartBeat{Tick: "hour"})
 		x.events <- event
 	})
 

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
+	"github.com/codeamp/circuit/plugins/heartbeat"
 	"github.com/codeamp/transistor"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -23,9 +24,12 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	viper.SetConfigType("YAML")
+	viper.SetConfigType("yaml")
 	viper.ReadConfig(bytes.NewBuffer(viperConfig))
-	viper.SetConfigType("yaml") // or viper.SetConfigType("YAML")
+
+	transistor.RegisterPlugin("heartbeat", func() transistor.Plugin {
+		return &heartbeat.Heartbeat{}
+	})
 
 	config := transistor.Config{
 		Plugins:        viper.GetStringMap("plugins"),
@@ -43,7 +47,7 @@ func (suite *TestSuite) TearDownSuite() {
 func (suite *TestSuite) TestHeartbeat() {
 	var e transistor.Event
 
-	e = suite.transistor.GetTestEvent("plugins.HeartBeat", 61)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), 61)
 	payload := e.Payload.(plugins.HeartBeat)
 	assert.Equal(suite.T(), "minute", payload.Tick)
 }

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -48,7 +48,7 @@ func (suite *TestSuite) TestHeartbeat() {
 	var e transistor.Event
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), 61)
-	payload := e.Payload.(plugins.HeartBeat)
+	payload := e.Payload().(plugins.HeartBeat)
 	assert.Equal(suite.T(), "minute", payload.Tick)
 }
 

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -48,7 +48,7 @@ func (suite *TestSuite) TestHeartbeat() {
 	var e transistor.Event
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), 61)
-	payload := e.Payload().(plugins.HeartBeat)
+	payload := e.Payload.(plugins.HeartBeat)
 	assert.Equal(suite.T(), "minute", payload.Tick)
 }
 

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -28,10 +28,6 @@ import (
 )
 
 func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
-	log.InfoWithFields("Processing Kubernetes Deployments event", log.Fields{
-		"event": e.Payload,
-	})
-
 	// There used to be a handler for a plugins.ReleaseExtension and a plugins.ProjectExtension
 	// but one of them didn't really do anything. Not sure if there are any events that are sent
 	// with those extensions or if handling them differently is important downstream

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -42,8 +42,7 @@ func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 	// }
 
 	if e.Event() == "kubernetes:deployment:update" {
-		event := e.NewEvent(plugins.GetAction("status"), e.Payload)
-		event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Name))
+		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Name))
 		x.events <- event
 
 		return

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -34,7 +34,7 @@ func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 	// ADB
 	// if e.Name == "kubernetes:deployment:create" {
 	// 	log.Info(e)
-	// 	event := e.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("status"), e.Payload)
+	// 	event := e.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("status"), e.Payload())
 	// 	event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s 1 has completed successfully", e.Name))
 	// 	x.events <- event
 
@@ -261,9 +261,9 @@ func genPodTemplateSpec(e transistor.Event, podConfig SimplePodSpec, kind string
 }
 
 func (x *Kubernetes) doDeploy(e transistor.Event) error {
-	log.Info(e.Payload)
+	log.Info(e.Payload())
 	// write kubeconfig
-	reData := e.Payload.(plugins.ReleaseExtension)
+	reData := e.Payload().(plugins.ReleaseExtension)
 	projectSlug := plugins.GetSlug(reData.Release.Project.Repository)
 
 	kubeconfig, err := x.SetupKubeConfig(e)
@@ -299,7 +299,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 
 	successfulDeploys := 0
 	// TODO: get timeout from formValues
-	//timeout := e.Payload.(plugins.ReleaseExtension).Release.Timeout
+	//timeout := e.Payload().(plugins.ReleaseExtension).Release.Timeout
 	// Set default timeout to 600 seconds if not specified.
 	//if timeout == 0 {
 	timeout := 600

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -28,14 +28,14 @@ import (
 )
 
 func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
-	if e.PayloadModel == "plugins.ProjectExtension" {
-		if e.Name == "kubernetes:deployment:create" {
+	if e.Matches("project:") {
+		if e.Action == transistor.GetAction("create") {
 			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 			return
 		}
 
-		if e.Event() == "kubernetes:deployment:update" {
+		if e.Action == transistor.GetAction("update") {
 			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 
@@ -43,8 +43,8 @@ func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 		}
 	}
 
-	if e.PayloadModel == "plugins.ReleaseExtension" {
-		if e.Event() == "kubernetes:deployment:create" {
+	if e.Matches("release:") {
+		if e.Action == transistor.GetAction("create") {
 			err := x.doDeploy(e)
 			if err != nil {
 				log.Error(err)

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -398,8 +398,6 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 		},
 	})
 
-	x.sendInProgress(e, "Secrets added to deployVolumes")
-
 	// Do update/create of deployments and services
 	depInterface := clientset.Extensions()
 	batchv1DepInterface := clientset.BatchV1()

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -42,7 +42,7 @@ func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 	// }
 
 	if e.Event() == "kubernetes:deployment:update" {
-		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Name))
+		event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 		x.events <- event
 
 		return

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -30,13 +30,13 @@ import (
 func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 	if e.PayloadModel == "plugins.ProjectExtension" {
 		if e.Name == "kubernetes:deployment:create" {
-			event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 			return
 		}
 
 		if e.Event() == "kubernetes:deployment:update" {
-			event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 
 			return
@@ -584,7 +584,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 			if job.Status.Active == int32(0) {
 				// Check for success
 				if job.Status.Succeeded == int32(service.Replicas) {
-					oneShotServices[index].State = plugins.GetState("complete")
+					oneShotServices[index].State = transistor.GetState("complete")
 					break
 				} else {
 					// Job has failed!
@@ -698,7 +698,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 
 		// Deployment
 		replicas := int32(service.Replicas)
-		if service.Action == plugins.GetAction("destroy") {
+		if service.Action == transistor.GetAction("delete") {
 			replicas = 0
 		}
 
@@ -810,7 +810,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 
 	log.Info(fmt.Sprintf("Waiting %d seconds for deployment to succeed.", timeout))
 	for i := range deploymentServices {
-		deploymentServices[i].State = plugins.GetState("waiting")
+		deploymentServices[i].State = transistor.GetState("waiting")
 	}
 
 	if len(deploymentServices) > 0 {
@@ -827,10 +827,10 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 				log.Info(fmt.Sprintf("Waiting for %s; ObservedGeneration: %d, Generation: %d, UpdatedReplicas: %d, Replicas: %d, AvailableReplicas: %d, UnavailableReplicas: %d", deploymentName, deployment.Status.ObservedGeneration, deployment.ObjectMeta.Generation, deployment.Status.UpdatedReplicas, *deployment.Spec.Replicas, deployment.Status.AvailableReplicas, deployment.Status.UnavailableReplicas))
 				if deployment.Status.ObservedGeneration >= deployment.ObjectMeta.Generation && deployment.Status.UpdatedReplicas == *deployment.Spec.Replicas && deployment.Status.AvailableReplicas >= deployment.Status.UpdatedReplicas && deployment.Status.UnavailableReplicas == 0 {
 					// deployment success
-					deploymentServices[index].State = plugins.GetState("complete")
+					deploymentServices[index].State = transistor.GetState("complete")
 					successfulDeploys = 0
 					for _, d := range deploymentServices {
-						if d.State == plugins.GetState("complete") {
+						if d.State == transistor.GetState("complete") {
 							successfulDeploys++
 						}
 					}
@@ -899,7 +899,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 
 	}
 
-	x.sendSuccessResponse(e, plugins.GetState("complete"), nil)
+	x.sendSuccessResponse(e, transistor.GetState("complete"), nil)
 
 	// all success!
 	log.Info(fmt.Sprintf("All deployments successful."))

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -34,7 +34,7 @@ func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 	// ADB
 	// if e.Name == "kubernetes:deployment:create" {
 	// 	log.Info(e)
-	// 	event := e.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("status"), e.Payload())
+	// 	event := e.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("status"), e.Payload)
 	// 	event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s 1 has completed successfully", e.Name))
 	// 	x.events <- event
 
@@ -261,9 +261,9 @@ func genPodTemplateSpec(e transistor.Event, podConfig SimplePodSpec, kind string
 }
 
 func (x *Kubernetes) doDeploy(e transistor.Event) error {
-	log.Info(e.Payload())
+	log.Info(e.Payload)
 	// write kubeconfig
-	reData := e.Payload().(plugins.ReleaseExtension)
+	reData := e.Payload.(plugins.ReleaseExtension)
 	projectSlug := plugins.GetSlug(reData.Release.Project.Repository)
 
 	kubeconfig, err := x.SetupKubeConfig(e)
@@ -299,7 +299,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 
 	successfulDeploys := 0
 	// TODO: get timeout from formValues
-	//timeout := e.Payload().(plugins.ReleaseExtension).Release.Timeout
+	//timeout := e.Payload.(plugins.ReleaseExtension).Release.Timeout
 	// Set default timeout to 600 seconds if not specified.
 	//if timeout == 0 {
 	timeout := 600

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -41,10 +41,9 @@ func (x *Kubernetes) ProcessDeployment(e transistor.Event) {
 	// 	return
 	// }
 
-	if e.Event() == "kubernetes:deplyment:update" {
-		log.Info("Creating weirdness")
-		event := e.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("status"), e.Payload)
-		event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s 2 has completed successfully", e.Name))
+	if e.Event() == "kubernetes:deployment:update" {
+		event := e.NewEvent(plugins.GetAction("status"), e.Payload)
+		event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Name))
 		x.events <- event
 
 		return

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -43,24 +43,27 @@ func (x *Kubernetes) Stop() {
 
 func (x *Kubernetes) Subscribe() []string {
 	return []string{
-		"kubernetes:deployment:create",
-		"kubernetes:deployment:update",
-		"kubernetes:deployment:delete",
-		"kubernetes:loadbalancer:create",
-		"kubernetes:loadbalancer:update",
-		"kubernetes:loadbalancer:delete",
+		"project:kubernetes:deployment:create",
+		"project:kubernetes:deployment:update",
+		"project:kubernetes:deployment:delete",
+		"project:kubernetes:loadbalancer:create",
+		"project:kubernetes:loadbalancer:update",
+		"project:kubernetes:loadbalancer:delete",
+		"release:kubernetes:deployment:create",
 	}
 }
 
 func (x *Kubernetes) Process(e transistor.Event) error {
-	log.DebugWithFields("Processing kubernetes event", log.Fields{
-		"event": e,
-	})
+	log.Debug("Processing kubernetes event")
 
-	if e.Matches("kubernetes:deployment") == true {
+	if e.Matches(".*:kubernetes:deployment") == true {
 		x.ProcessDeployment(e)
-	} else if e.Matches("kubernetes:loadbalancer") == true {
+		return nil
+	}
+
+	if e.Matches(".*:kubernetes:loadbalancer") == true {
 		x.ProcessLoadBalancer(e)
+		return nil
 	}
 
 	return nil

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -24,7 +24,6 @@ func init() {
 
 func (x *Kubernetes) Description() string {
 	return "Kubernetes"
-
 }
 
 func (x *Kubernetes) SampleConfig() string {
@@ -46,11 +45,11 @@ func (x *Kubernetes) Subscribe() []string {
 	return []string{
 		"kubernetes:deployment:create",
 		"kubernetes:deployment:update",
-		"kubernetes:deployment:delete",
+		"kubernetes:deployment:destroy",
 
 		"kubernetes:loadbalancer:create",
 		"kubernetes:loadbalancer:update",
-		"kubernetes:loadbalancer:delete",
+		"kubernetes:loadbalancer:destroy",
 	}
 }
 
@@ -69,7 +68,7 @@ func (x *Kubernetes) Process(e transistor.Event) error {
 }
 
 func (x *Kubernetes) sendSuccessResponse(e transistor.Event, state transistor.State, artifacts []transistor.Artifact) {
-	event := e.NewEvent(e.Name, plugins.GetAction("status"), e.Payload)
+	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
 	event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 	event.Artifacts = artifacts
 
@@ -77,14 +76,14 @@ func (x *Kubernetes) sendSuccessResponse(e transistor.Event, state transistor.St
 }
 
 func (x *Kubernetes) sendErrorResponse(e transistor.Event, msg string) {
-	event := e.NewEvent(e.Name, plugins.GetAction("status"), e.Payload)
+	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
 	event.SetState(plugins.GetState("failed"), msg)
 
 	x.events <- event
 }
 
 func (x *Kubernetes) sendInProgress(e transistor.Event, msg string) {
-	event := e.NewEvent(e.Name, plugins.GetAction("status"), e.Payload)
+	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
 	event.SetState(plugins.GetState("running"), msg)
 
 	x.events <- event

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -68,24 +68,19 @@ func (x *Kubernetes) Process(e transistor.Event) error {
 }
 
 func (x *Kubernetes) sendSuccessResponse(e transistor.Event, state transistor.State, artifacts []transistor.Artifact) {
-	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
-	event.SetState(plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 	event.Artifacts = artifacts
 
 	x.events <- event
 }
 
 func (x *Kubernetes) sendErrorResponse(e transistor.Event, msg string) {
-	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
-	event.SetState(plugins.GetState("failed"), msg)
-
+	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), msg)
 	x.events <- event
 }
 
 func (x *Kubernetes) sendInProgress(e transistor.Event, msg string) {
-	event := e.NewEvent(plugins.GetAction("status"), e.Payload)
-	event.SetState(plugins.GetState("running"), msg)
-
+	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("running"), msg)
 	x.events <- event
 }
 

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -45,10 +45,10 @@ func (x *Kubernetes) Subscribe() []string {
 	return []string{
 		"kubernetes:deployment:create",
 		"kubernetes:deployment:update",
-		"kubernetes:deployment:destroy",
+		"kubernetes:deployment:delete",
 		"kubernetes:loadbalancer:create",
 		"kubernetes:loadbalancer:update",
-		"kubernetes:loadbalancer:destroy",
+		"kubernetes:loadbalancer:delete",
 	}
 }
 
@@ -67,19 +67,19 @@ func (x *Kubernetes) Process(e transistor.Event) error {
 }
 
 func (x *Kubernetes) sendSuccessResponse(e transistor.Event, state transistor.State, artifacts []transistor.Artifact) {
-	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+	event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 	event.Artifacts = artifacts
 
 	x.events <- event
 }
 
 func (x *Kubernetes) sendErrorResponse(e transistor.Event, msg string) {
-	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), msg)
+	event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("failed"), msg)
 	x.events <- event
 }
 
 func (x *Kubernetes) sendInProgress(e transistor.Event, msg string) {
-	event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("running"), msg)
+	event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("running"), msg)
 	x.events <- event
 }
 

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -46,7 +46,6 @@ func (x *Kubernetes) Subscribe() []string {
 		"kubernetes:deployment:create",
 		"kubernetes:deployment:update",
 		"kubernetes:deployment:destroy",
-
 		"kubernetes:loadbalancer:create",
 		"kubernetes:loadbalancer:update",
 		"kubernetes:loadbalancer:destroy",

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -55,7 +55,7 @@ func (x *Kubernetes) Subscribe() []string {
 }
 
 func (x *Kubernetes) Process(e transistor.Event) error {
-	log.InfoWithFields("Processing kubernetes event", log.Fields{
+	log.DebugWithFields("Processing kubernetes event", log.Fields{
 		"event": e,
 	})
 

--- a/plugins/kubernetes/kubernetes.go
+++ b/plugins/kubernetes/kubernetes.go
@@ -19,7 +19,7 @@ import (
 func init() {
 	transistor.RegisterPlugin("kubernetes", func() transistor.Plugin {
 		return &Kubernetes{}
-	})
+	}, plugins.ReleaseExtension{}, plugins.ProjectExtension{})
 }
 
 func (x *Kubernetes) Description() string {

--- a/plugins/kubernetes/kubernetes_test.go
+++ b/plugins/kubernetes/kubernetes_test.go
@@ -54,7 +54,7 @@ func (suite *TestSuite) SetupSuite() {
 
 // Load Balancers Tests
 func (suite *TestSuite) TestCleanupLBOffice() {
-	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("destroy"), plugins.GetType("office"))
+	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("delete"), plugins.GetType("office"))
 
 	e := suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), plugins.GetAction("status"), 60)
 	assert.Equal(suite.T(), plugins.GetState("deleted"), e.State, e.StateMessage)
@@ -85,7 +85,7 @@ func (suite *TestSuite) TestLBTCPOffice() {
 		}
 	}
 
-	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("destroy"), plugins.GetType("office"))
+	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("delete"), plugins.GetType("office"))
 
 	e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), plugins.GetAction("status"), 10)
 	assert.Equal(suite.T(), plugins.GetState("deleted"), e.State)

--- a/plugins/kubernetes/kubernetes_test.go
+++ b/plugins/kubernetes/kubernetes_test.go
@@ -333,7 +333,7 @@ func BasicReleaseExtension() plugins.ReleaseExtension {
 			Workdir:       "/tmp/something",
 		},
 		Services: []plugins.Service{
-			plugins.Service{
+			{
 				Name: "www",
 				Listeners: []plugins.Listener{
 					{

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -20,21 +20,7 @@ import (
 )
 
 func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
-	if e.Matches("project:") {
-		if e.Action == transistor.GetAction("create") {
-			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
-			x.events <- event
-			return
-		}
-
-		if e.Action == transistor.GetAction("update") {
-			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
-			x.events <- event
-			return
-		}
-	}
-
-	if e.Matches("release:") {
+	if e.Matches("project:kubernetes:loadbalancer") {
 		var err error
 		switch e.Action {
 		case transistor.GetAction("delete"):

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -20,21 +20,21 @@ import (
 )
 
 func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
-	if e.PayloadModel == "plugins.ProjectExtension" {
-		if e.Name == "kubernetes:loadbalancer:create" {
+	if e.Matches("project:") {
+		if e.Action == transistor.GetAction("create") {
 			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 			return
 		}
 
-		if e.Event() == "kubernetes:loadbalancer:update" {
+		if e.Action == transistor.GetAction("update") {
 			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 			return
 		}
 	}
 
-	if e.PayloadModel == "plugins.ReleaseExtension" {
+	if e.Matches("release:") {
 		var err error
 		switch e.Action {
 		case transistor.GetAction("delete"):

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -41,7 +41,7 @@ func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
 
 func (x *Kubernetes) doLoadBalancer(e transistor.Event) error {
 	log.Info("doLoadBalancer")
-	payload := e.Payload().(plugins.ProjectExtension)
+	payload := e.Payload.(plugins.ProjectExtension)
 	svcName, err := e.GetArtifact("service")
 	if err != nil {
 		log.Warn("missing service")
@@ -319,7 +319,7 @@ func (x *Kubernetes) doDeleteLoadBalancer(e transistor.Event) error {
 func deleteLoadBalancer(e transistor.Event, x *Kubernetes) error {
 	log.Info("deleteLoadBalancer")
 	var err error
-	payload := e.Payload().(plugins.ProjectExtension)
+	payload := e.Payload.(plugins.ProjectExtension)
 
 	kubeconfig, err := x.SetupKubeConfig(e)
 	if err != nil {

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -41,7 +41,7 @@ func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
 
 func (x *Kubernetes) doLoadBalancer(e transistor.Event) error {
 	log.Info("doLoadBalancer")
-	payload := e.Payload.(plugins.ProjectExtension)
+	payload := e.Payload().(plugins.ProjectExtension)
 	svcName, err := e.GetArtifact("service")
 	if err != nil {
 		log.Warn("missing service")
@@ -319,7 +319,7 @@ func (x *Kubernetes) doDeleteLoadBalancer(e transistor.Event) error {
 func deleteLoadBalancer(e transistor.Event, x *Kubernetes) error {
 	log.Info("deleteLoadBalancer")
 	var err error
-	payload := e.Payload.(plugins.ProjectExtension)
+	payload := e.Payload().(plugins.ProjectExtension)
 
 	kubeconfig, err := x.SetupKubeConfig(e)
 	if err != nil {

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -22,13 +22,13 @@ import (
 func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
 	if e.PayloadModel == "plugins.ProjectExtension" {
 		if e.Name == "kubernetes:loadbalancer:create" {
-			event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 			return
 		}
 
 		if e.Event() == "kubernetes:loadbalancer:update" {
-			event := e.NewEvent(plugins.GetAction("status"), plugins.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+			event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
 			x.events <- event
 			return
 		}
@@ -37,11 +37,11 @@ func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
 	if e.PayloadModel == "plugins.ReleaseExtension" {
 		var err error
 		switch e.Action {
-		case plugins.GetAction("destroy"):
+		case transistor.GetAction("delete"):
 			err = x.doDeleteLoadBalancer(e)
-		case plugins.GetAction("create"):
+		case transistor.GetAction("create"):
 			err = x.doLoadBalancer(e)
-		case plugins.GetAction("update"):
+		case transistor.GetAction("update"):
 			err = x.doLoadBalancer(e)
 		}
 
@@ -312,7 +312,7 @@ func (x *Kubernetes) doLoadBalancer(e transistor.Event) error {
 	artifacts[0] = transistor.Artifact{Key: "dns", Value: ELBDNS, Secret: false}
 	artifacts[1] = transistor.Artifact{Key: "name", Value: lbName.String(), Secret: false}
 
-	x.sendSuccessResponse(e, plugins.GetState("complete"), artifacts)
+	x.sendSuccessResponse(e, transistor.GetState("complete"), artifacts)
 	return nil
 }
 
@@ -324,7 +324,7 @@ func (x *Kubernetes) doDeleteLoadBalancer(e transistor.Event) error {
 		x.sendErrorResponse(e, err.Error())
 	} else {
 		log.Warn("sending success deleted")
-		x.sendSuccessResponse(e, plugins.GetState("deleted"), nil)
+		x.sendSuccessResponse(e, transistor.GetState("deleted"), nil)
 	}
 
 	return nil

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -20,6 +20,8 @@ import (
 )
 
 func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
+	log.Info("ProcessLoadBalancer")
+	log.Info(e)
 	var err error
 	switch e.Action {
 	case plugins.GetAction("destroy"):
@@ -38,6 +40,7 @@ func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
 }
 
 func (x *Kubernetes) doLoadBalancer(e transistor.Event) error {
+	log.Info("doLoadBalancer")
 	payload := e.Payload.(plugins.ProjectExtension)
 	svcName, err := e.GetArtifact("service")
 	if err != nil {
@@ -300,6 +303,7 @@ func (x *Kubernetes) doLoadBalancer(e transistor.Event) error {
 }
 
 func (x *Kubernetes) doDeleteLoadBalancer(e transistor.Event) error {
+	log.Info("doDeleteLoadBalancer")
 	err := deleteLoadBalancer(e, x)
 
 	if err != nil {

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -20,10 +20,6 @@ import (
 )
 
 func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
-	log.InfoWithFields("Processing load balancer event", log.Fields{
-		"event": e,
-	})
-
 	var err error
 	switch e.Action {
 	case plugins.GetAction("destroy"):

--- a/plugins/kubernetes/loadbalancer.go
+++ b/plugins/kubernetes/loadbalancer.go
@@ -24,10 +24,8 @@ func (x *Kubernetes) ProcessLoadBalancer(e transistor.Event) {
 		"event": e,
 	})
 
-	event := e.Payload.(plugins.ProjectExtension)
-
 	var err error
-	switch event.Action {
+	switch e.Action {
 	case plugins.GetAction("destroy"):
 		err = x.doDeleteLoadBalancer(e)
 	case plugins.GetAction("create"):
@@ -311,6 +309,7 @@ func (x *Kubernetes) doDeleteLoadBalancer(e transistor.Event) error {
 	if err != nil {
 		x.sendErrorResponse(e, err.Error())
 	} else {
+		log.Warn("sending success deleted")
 		x.sendSuccessResponse(e, plugins.GetState("deleted"), nil)
 	}
 
@@ -318,6 +317,7 @@ func (x *Kubernetes) doDeleteLoadBalancer(e transistor.Event) error {
 }
 
 func deleteLoadBalancer(e transistor.Event, x *Kubernetes) error {
+	log.Info("deleteLoadBalancer")
 	var err error
 	payload := e.Payload.(plugins.ProjectExtension)
 

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -81,7 +81,7 @@ func (x *Route53) sendRoute53Response(e transistor.Event, action transistor.Acti
 	}
 
 	event := e.NewEvent(action, state, stateMessage)
-	event.AddArtifact("plugins.ProjectExtension", projectExtension, false)
+	event.SetPayload(projectExtension)
 	x.events <- event
 }
 

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -47,8 +47,8 @@ func (x *Route53) Stop() {
 
 func (x *Route53) Subscribe() []string {
 	return []string{
-		"plugins.ProjectExtension:create:route53",
-		"plugins.ProjectExtension:update:route53",
+		"route53:create",
+		"route53:update",
 	}
 }
 

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -47,8 +47,9 @@ func (x *Route53) Stop() {
 
 func (x *Route53) Subscribe() []string {
 	return []string{
-		"route53:create",
-		"route53:update",
+		"project:route53:create",
+		"project:route53:update",
+		"project:route53:delete",
 	}
 }
 
@@ -56,7 +57,7 @@ func (x *Route53) Process(e transistor.Event) error {
 	var err error
 	log.Info("Processing route53 event")
 
-	if e.PayloadModel == "plugins.ProjectExtension" {
+	if e.Matches("project:route53") {
 		switch e.Action {
 		case transistor.GetAction("create"):
 			log.InfoWithFields(fmt.Sprintf("Process Route53 event: %s", e.Event()), log.Fields{})
@@ -64,6 +65,8 @@ func (x *Route53) Process(e transistor.Event) error {
 		case transistor.GetAction("update"):
 			log.InfoWithFields(fmt.Sprintf("Process Route53 event: %s", e.Event()), log.Fields{})
 			err = x.updateRoute53(e)
+		default:
+			log.InfoWithFields(fmt.Sprintf("Unhandled Route53 event: %s", e.Event()), log.Fields{})
 		}
 
 		if err != nil {

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -86,7 +86,7 @@ func (x *Route53) sendRoute53Response(e transistor.Event, action transistor.Acti
 }
 
 func (x *Route53) updateRoute53(e transistor.Event) error {
-	payload := e.Payload().(plugins.ProjectExtension)
+	payload := e.Payload.(plugins.ProjectExtension)
 
 	elbFQDN, err := e.GetArtifact("loadbalancer_fqdn")
 	if err != nil {

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -56,18 +56,20 @@ func (x *Route53) Process(e transistor.Event) error {
 	var err error
 	log.Info("Processing route53 event")
 
-	switch e.Action {
-	case plugins.GetAction("create"):
-		log.InfoWithFields(fmt.Sprintf("Process Route53 event: %s", e.Event()), log.Fields{})
-		err = x.updateRoute53(e)
-	case plugins.GetAction("update"):
-		log.InfoWithFields(fmt.Sprintf("Process Route53 event: %s", e.Event()), log.Fields{})
-		err = x.updateRoute53(e)
-	}
+	if e.PayloadModel == "plugins.ProjectExtension" {
+		switch e.Action {
+		case plugins.GetAction("create"):
+			log.InfoWithFields(fmt.Sprintf("Process Route53 event: %s", e.Event()), log.Fields{})
+			err = x.updateRoute53(e)
+		case plugins.GetAction("update"):
+			log.InfoWithFields(fmt.Sprintf("Process Route53 event: %s", e.Event()), log.Fields{})
+			err = x.updateRoute53(e)
+		}
 
-	if err != nil {
-		x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: Route53", err.Error(), e.State))
-		return nil
+		if err != nil {
+			x.events <- e.NewEvent(plugins.GetAction("status"), plugins.GetState("failed"), fmt.Sprintf("%v (Action: %v, Step: Route53", err.Error(), e.State))
+			return nil
+		}
 	}
 
 	return nil

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -24,7 +24,7 @@ type Route53 struct {
 func init() {
 	transistor.RegisterPlugin("route53", func() transistor.Plugin {
 		return &Route53{}
-	})
+	}, plugins.ProjectExtension{})
 }
 
 func (x *Route53) Description() string {

--- a/plugins/route53/route53.go
+++ b/plugins/route53/route53.go
@@ -86,7 +86,7 @@ func (x *Route53) sendRoute53Response(e transistor.Event, action transistor.Acti
 }
 
 func (x *Route53) updateRoute53(e transistor.Event) error {
-	payload := e.Payload.(plugins.ProjectExtension)
+	payload := e.Payload().(plugins.ProjectExtension)
 
 	elbFQDN, err := e.GetArtifact("loadbalancer_fqdn")
 	if err != nil {

--- a/vendor/github.com/codeamp/transistor/.circleci/config.yml
+++ b/vendor/github.com/codeamp/transistor/.circleci/config.yml
@@ -1,0 +1,27 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.9
+      
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/codeamp/transistor
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go build -v ./...
+      - run: go test -v ./...

--- a/vendor/github.com/codeamp/transistor/Gopkg.lock
+++ b/vendor/github.com/codeamp/transistor/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "master"
   name = "github.com/codeamp/logger"
   packages = ["."]
-  revision = "3af44e5f22c2a3ace490347b8f65e51db8d28126"
+  revision = "02beb4f2edb3743a722a3997f48fc5e67c6abd0c"
 
 [[projects]]
   name = "github.com/garyburd/redigo"

--- a/vendor/github.com/codeamp/transistor/README.md
+++ b/vendor/github.com/codeamp/transistor/README.md
@@ -10,7 +10,6 @@ package plugins
 import "github.com/codeamp/transistor"
 
 func init() {
-    transistor.RegisterApi(Hello{})
 }
 
 type Hello struct {
@@ -46,11 +45,11 @@ func (x *ExamplePlugin1) Start(e chan transistor.Event) error {
 	log.Info("starting ExamplePlugin")
 
 	event := Hello{
-		Action:  "examplePlugin2",
+		Action:  "examplePlugin1",
 		Message: "Hello World from ExamplePlugin1",
 	}
 
-	e <- transistor.NewEvent(event, nil)
+	e <- transistor.NewEvent(transistor.EventName("exampleplugin1"), transistor.Action("create"), nil)
 
 	return nil
 }
@@ -59,10 +58,10 @@ func (x *ExamplePlugin1) Start(e chan transistor.Event) error {
 or respond to existing one and keep track of parent event
 
 ```go
-func (x *ExamplePlugin1) Process(e transistor.Event) error {
-	if e.Name == "plugins.Hello:examplePlugin2" {
+func (x *ExamplePlugin2) Process(e transistor.Event) error {
+	if e.Name == "exampleplugin2:create" {
 		hello := e.Payload.(Hello)
-		log.Info("ExamplePlugin1 received a message:", hello)
+		log.Info("ExamplePlugin2 received a message:", hello)
 	}
 	return nil
 }
@@ -79,16 +78,16 @@ func main() {
 		Process:  "1",
 		Queueing: true,
 		Plugins: map[string]interface{}{
-			"examplePlugin1": map[string]interface{}{
+			"exampleplugin1": map[string]interface{}{
 				"hello":   "world1",
 				"workers": 1,
 			},
-			"examplePlugin2": map[string]interface{}{
+			"exampleplugin2": map[string]interface{}{
 				"hello":   "world2",
 				"workers": 1,
 			},
 		},
-		EnabledPlugins: []string{"examplePlugin1", "examplePlugin2"},
+		EnabledPlugins: []string{"exampleplugin1", "exampleplugin2"},
 	}
 
 	t, err := transistor.NewTransistor(config)

--- a/vendor/github.com/codeamp/transistor/README.md
+++ b/vendor/github.com/codeamp/transistor/README.md
@@ -60,7 +60,7 @@ or respond to existing one and keep track of parent event
 ```go
 func (x *ExamplePlugin2) Process(e transistor.Event) error {
 	if e.Name == "exampleplugin2:create" {
-		hello := e.Payload.(Hello)
+		hello := e.Payload().(Hello)
 		log.Info("ExamplePlugin2 received a message:", hello)
 	}
 	return nil

--- a/vendor/github.com/codeamp/transistor/README.md
+++ b/vendor/github.com/codeamp/transistor/README.md
@@ -1,4 +1,4 @@
-# Transistor
+# Transistor [![CircleCI](https://circleci.com/gh/codeamp/transistor.svg?style=svg)](https://circleci.com/gh/codeamp/transistor) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Coverage Status](https://coveralls.io/repos/github/codeamp/transistor/badge.svg?branch=master)](https://coveralls.io/github/codeamp/transistor?branch=master) [![Go Report Card](https://goreportcard.com/badge/codeamp/transistor)](https://goreportcard.com/report/codeamp/transistor) [![codebeat badge](https://codebeat.co/badges/b977a7e7-1e94-43e1-9e58-463cff99add3)](https://codebeat.co/projects/github-com-codeamp-transistor-master)
 
 Transistor allows you to run distributed workload on one or accross multiple hosts. It's a plugin based system that allows plugins to subscribe to multiple events and internal scheduler takes care of delivery. This allows multiple plugins to recieve same message do some work and respond with updated or different message.
 

--- a/vendor/github.com/codeamp/transistor/event.go
+++ b/vendor/github.com/codeamp/transistor/event.go
@@ -53,8 +53,8 @@ type Event struct {
 	State        State  `json:"state"`
 	StateMessage string `json:"stateMessage"`
 
-	Payload      interface{} `json:"payload"`
-	PayloadModel string      `json:"payloadModel"`
+	payload      interface{} `json:"payload"`
+	payloadModel string      `json:"payloadModel"`
 	CreatedAt    time.Time   `json:"createdAt"`
 	Caller       Caller      `json:"caller"`
 	Artifacts    []Artifact  `json:"artifacts"`
@@ -109,16 +109,13 @@ func NewEvent(eventName EventName, action Action, payload interface{}) Event {
 	event := Event{
 		ID:           uuid.NewV4(),
 		Name:         eventName,
-		Payload:      payload,
 		CreatedAt:    time.Now(),
 		Action:       action,
 		State:        State("waiting"),
 		StateMessage: "Waiting for event to run",
 	}
 
-	if payload != nil {
-		event.PayloadModel = reflect.TypeOf(payload).String()
-	}
+	event.SetPayload(payload)
 
 	// for debugging purposes
 	_, file, no, ok := runtime.Caller(1)
@@ -155,11 +152,19 @@ func (e *Event) NewEvent(action Action, state State, stateMessage string) Event 
 	return event
 }
 
-func (e *Event) OverridePayload(payload interface{}) {
-	e.Payload = payload
+func (e *Event) Payload() interface{} {
+	return e.payload
+}
+
+func (e *Event) SetPayload(payload interface{}) {
+	e.payload = payload
 	if payload != nil {
-		e.PayloadModel = reflect.TypeOf(payload).String()
+		e.payloadModel = reflect.TypeOf(payload).String()
 	}
+}
+
+func (e *Event) PayloadModel() string {
+	return e.payloadModel
 }
 
 func (e *Event) Dump() {

--- a/vendor/github.com/codeamp/transistor/event.go
+++ b/vendor/github.com/codeamp/transistor/event.go
@@ -53,8 +53,8 @@ type Event struct {
 	State        State  `json:"state"`
 	StateMessage string `json:"stateMessage"`
 
-	payload      interface{} `json:"payload"`
-	payloadModel string      `json:"payloadModel"`
+	Payload      interface{} `json:"payload"`
+	PayloadModel string      `json:"payloadModel"`
 	CreatedAt    time.Time   `json:"createdAt"`
 	Caller       Caller      `json:"caller"`
 	Artifacts    []Artifact  `json:"artifacts"`
@@ -152,19 +152,13 @@ func (e *Event) NewEvent(action Action, state State, stateMessage string) Event 
 	return event
 }
 
-func (e *Event) Payload() interface{} {
-	return e.payload
-}
-
 func (e *Event) SetPayload(payload interface{}) {
-	e.payload = payload
+	e.Payload = payload
 	if payload != nil {
-		e.payloadModel = reflect.TypeOf(payload).String()
+		e.PayloadModel = reflect.TypeOf(payload).String()
+	} else {
+		e.PayloadModel = ""
 	}
-}
-
-func (e *Event) PayloadModel() string {
-	return e.payloadModel
 }
 
 func (e *Event) Dump() {

--- a/vendor/github.com/codeamp/transistor/event.go
+++ b/vendor/github.com/codeamp/transistor/event.go
@@ -12,6 +12,7 @@ import (
 
 	json "github.com/bww/go-json"
 	log "github.com/codeamp/logger"
+	"github.com/davecgh/go-spew/spew"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -27,6 +28,7 @@ func GetAction(s string) Action {
 		"status",
 	}
 
+	spew.Dump()
 	for _, action := range actions {
 		if s == action {
 			return Action(action)

--- a/vendor/github.com/codeamp/transistor/event.go
+++ b/vendor/github.com/codeamp/transistor/event.go
@@ -12,7 +12,6 @@ import (
 
 	json "github.com/bww/go-json"
 	log "github.com/codeamp/logger"
-	"github.com/davecgh/go-spew/spew"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -28,7 +27,6 @@ func GetAction(s string) Action {
 		"status",
 	}
 
-	spew.Dump()
 	for _, action := range actions {
 		if s == action {
 			return Action(action)
@@ -44,6 +42,31 @@ func GetAction(s string) Action {
 	log.Panic(errMsg)
 
 	return Action("unknown")
+}
+
+func GetState(s string) State {
+	states := []string{
+		"waiting",
+		"running",
+		"complete",
+		"failed",
+	}
+
+	for _, state := range states {
+		if s == state {
+			return State(state)
+		}
+	}
+
+	errMsg := fmt.Sprintf("State not found: '%s' ", s)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		errMsg += fmt.Sprintf("%s : ln %d", file, line)
+	}
+
+	log.Panic(errMsg)
+
+	return State("unknown")
 }
 
 type Event struct {

--- a/vendor/github.com/codeamp/transistor/event.go
+++ b/vendor/github.com/codeamp/transistor/event.go
@@ -12,16 +12,49 @@ import (
 
 	json "github.com/bww/go-json"
 	log "github.com/codeamp/logger"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
+type Action string
+type State string
+type EventName string
+
+func GetAction(s string) Action {
+	actions := []string{
+		"create",
+		"update",
+		"delete",
+		"status",
+	}
+
+	for _, action := range actions {
+		if s == action {
+			return Action(action)
+		}
+	}
+
+	errMsg := fmt.Sprintf("Action not found: '%s' ", s)
+	_, file, line, ok := runtime.Caller(1)
+	if ok {
+		errMsg += fmt.Sprintf("%s : ln %d", file, line)
+	}
+
+	log.Panic(errMsg)
+
+	return Action("unknown")
+}
+
 type Event struct {
-	ID           uuid.UUID   `json:"id"`
-	ParentID     uuid.UUID   `json:"parentId"`
-	Name         string      `json:"name"`
+	ID       uuid.UUID `json:"id"`
+	ParentID uuid.UUID `json:"parentId"`
+	Name     EventName `json:"name"`
+
+	Action       Action `json:"action"`
+	State        State  `json:"state"`
+	StateMessage string `json:"stateMessage"`
+
 	Payload      interface{} `json:"payload"`
 	PayloadModel string      `json:"payloadModel"`
-	Error        error       `json:"error"`
 	CreatedAt    time.Time   `json:"createdAt"`
 	Caller       Caller      `json:"caller"`
 	Artifacts    []Artifact  `json:"artifacts"`
@@ -60,42 +93,31 @@ func (a *Artifact) StringSlice() []interface{} {
 	return a.Value.([]interface{})
 }
 
-func name(payload interface{}) string {
-	s := reflect.ValueOf(payload)
-
-	if s.Kind() != reflect.Struct {
-		return reflect.TypeOf(payload).String()
-	}
-
-	name := reflect.TypeOf(payload).String()
-
-	f := s.FieldByName("Action")
-	if f.IsValid() {
-		action := f.String()
-		if action != "" {
-			name = fmt.Sprintf("%v:%v", name, action)
-		}
-	}
-
-	f = s.FieldByName("Slug")
-	if f.IsValid() {
-		slug := f.String()
-		if slug != "" {
-			name = fmt.Sprintf("%v:%v", name, slug)
-		}
-	}
-
-	return name
+func CreateEvent(eventName EventName, payload interface{}) Event {
+	return NewEvent(eventName, GetAction("create"), payload)
 }
 
-func NewEvent(payload interface{}, err error) Event {
+func UpdateEvent(eventName EventName, payload interface{}) Event {
+	return NewEvent(eventName, GetAction("update"), payload)
+}
+
+func DeleteEvent(eventName EventName, payload interface{}) Event {
+	return NewEvent(eventName, GetAction("delete"), payload)
+}
+
+func NewEvent(eventName EventName, action Action, payload interface{}) Event {
 	event := Event{
 		ID:           uuid.NewV4(),
-		Name:         name(payload),
+		Name:         eventName,
 		Payload:      payload,
-		PayloadModel: reflect.TypeOf(payload).String(),
-		Error:        err,
 		CreatedAt:    time.Now(),
+		Action:       action,
+		State:        State("waiting"),
+		StateMessage: "Waiting for event to run",
+	}
+
+	if payload != nil {
+		event.PayloadModel = reflect.TypeOf(payload).String()
 	}
 
 	// for debugging purposes
@@ -110,27 +132,34 @@ func NewEvent(payload interface{}, err error) Event {
 	return event
 }
 
-func (e *Event) NewEvent(payload interface{}, err error) Event {
-	event := Event{
-		ID:           uuid.NewV4(),
-		ParentID:     e.ID,
-		Name:         name(payload),
-		Payload:      payload,
-		PayloadModel: reflect.TypeOf(payload).String(),
-		Error:        err,
-		CreatedAt:    time.Now(),
-	}
+func (e *Event) CreateEvent(action Action, state State, stateMessage string) Event {
+	return e.NewEvent(GetAction("create"), state, stateMessage)
+}
 
-	// for debugging purposes
-	_, file, no, ok := runtime.Caller(1)
-	if ok {
-		event.Caller = Caller{
-			File:       file,
-			LineNumber: no,
-		}
-	}
+func (e *Event) UpdateEvent(action Action, state State, stateMessage string) Event {
+	return e.NewEvent(GetAction("update"), state, stateMessage)
+}
+func (e *Event) DeleteEvent(action Action, state State, stateMessage string) Event {
+	return e.NewEvent(GetAction("delete"), state, stateMessage)
+}
 
+func (e *Event) StatusEvent(action Action, state State, stateMessage string) Event {
+	return e.NewEvent(GetAction("status"), state, stateMessage)
+}
+
+func (e *Event) NewEvent(action Action, state State, stateMessage string) Event {
+	event := NewEvent(e.Name, action, e.Payload)
+	event.ParentID = e.ID
+	event.State = state
+	event.StateMessage = stateMessage
 	return event
+}
+
+func (e *Event) OverridePayload(payload interface{}) {
+	e.Payload = payload
+	if payload != nil {
+		e.PayloadModel = reflect.TypeOf(payload).String()
+	}
 }
 
 func (e *Event) Dump() {
@@ -138,12 +167,16 @@ func (e *Event) Dump() {
 	log.Info(string(event))
 }
 
+func (e *Event) Event() string {
+	return fmt.Sprintf("%s:%s", e.Name, e.Action)
+}
+
 func (e *Event) Matches(name string) bool {
-	matched, err := regexp.MatchString(name, e.Name)
+	matched, err := regexp.MatchString(name, e.Event())
 	if err != nil {
-		log.InfoWithFields("Event regex match encountered an error", log.Fields{
+		log.ErrorWithFields("Event regex match encountered an error", log.Fields{
 			"regex":  name,
-			"string": e.Name,
+			"string": e.Event(),
 			"error":  err,
 		})
 	}
@@ -152,10 +185,14 @@ func (e *Event) Matches(name string) bool {
 		return true
 	}
 
-	log.DebugWithFields("Event regex not matched", log.Fields{
-		"regex":  name,
-		"string": e.Name,
-	})
+	// Not that important because there will be events that will
+	// fail without being an error condition because there will obviously
+	// be some events that do not match. Leaving here for future debugging, but disabling for sake of DEBUG channel
+	// ADB
+	// log.DebugWithFields("Event regex not matched", log.Fields{
+	// 	"regex":  name,
+	// 	"string": e.Event(),
+	// })
 
 	return false
 }

--- a/vendor/github.com/codeamp/transistor/example/plugins/api.go
+++ b/vendor/github.com/codeamp/transistor/example/plugins/api.go
@@ -1,9 +1,6 @@
 package plugins
 
-import "github.com/codeamp/transistor"
-
 func init() {
-	transistor.RegisterApi(Hello{})
 }
 
 type Hello struct {

--- a/vendor/github.com/codeamp/transistor/example/plugins/examplePlugin1.go
+++ b/vendor/github.com/codeamp/transistor/example/plugins/examplePlugin1.go
@@ -19,13 +19,12 @@ func init() {
 func (x *ExamplePlugin1) Start(e chan transistor.Event) error {
 	log.Info("starting ExamplePlugin")
 
-	event := Hello{
-		Action:  "examplePlugin2",
+	payload := Hello{
+		Action:  "examplePlugin1",
 		Message: "Hello World from ExamplePlugin1",
 	}
 
-	e <- transistor.NewEvent(event, nil)
-
+	e <- transistor.CreateEvent(transistor.EventName("examplePlugin1"), payload)
 	return nil
 }
 
@@ -35,12 +34,12 @@ func (x *ExamplePlugin1) Stop() {
 
 func (x *ExamplePlugin1) Subscribe() []string {
 	return []string{
-		"plugins.Hello:examplePlugin2",
+		"examplePlugin2",
 	}
 }
 
 func (x *ExamplePlugin1) Process(e transistor.Event) error {
-	if e.Name == "plugins.Hello:examplePlugin2" {
+	if e.Event() == "examplePlugin1:create" {
 		hello := e.Payload.(Hello)
 		log.Info("ExamplePlugin1 received a message:", hello)
 	}

--- a/vendor/github.com/codeamp/transistor/example/plugins/examplePlugin2.go
+++ b/vendor/github.com/codeamp/transistor/example/plugins/examplePlugin2.go
@@ -19,12 +19,12 @@ func init() {
 func (x *ExamplePlugin2) Start(e chan transistor.Event) error {
 	log.Info("starting ExamplePlugin2")
 
-	event := Hello{
-		Action:  "examplePlugin1",
+	payload := Hello{
+		Action:  "examplePlugin2",
 		Message: "Hello World from ExamplePlugin2",
 	}
 
-	e <- transistor.NewEvent(event, nil)
+	e <- transistor.CreateEvent(transistor.EventName("examplePlugin2"), payload)
 
 	return nil
 }
@@ -35,12 +35,12 @@ func (x *ExamplePlugin2) Stop() {
 
 func (x *ExamplePlugin2) Subscribe() []string {
 	return []string{
-		"plugins.Hello:examplePlugin1",
+		"examplePlugin1:create",
 	}
 }
 
 func (x *ExamplePlugin2) Process(e transistor.Event) error {
-	if e.Name == "plugins.Hello:examplePlugin1" {
+	if e.Event() == "examplePlugin2:create" {
 		hello := e.Payload.(Hello)
 		log.Info("ExamplePlugin2 received a message:", hello)
 	}

--- a/vendor/github.com/codeamp/transistor/registry.go
+++ b/vendor/github.com/codeamp/transistor/registry.go
@@ -1,18 +1,9 @@
 package transistor
 
-import (
-	"reflect"
-)
-
 type Creator func() Plugin
 
 var PluginRegistry = map[string]Creator{}
-var EventRegistry = make(map[string]interface{})
 
 func RegisterPlugin(name string, creator Creator) {
 	PluginRegistry[name] = creator
-}
-
-func RegisterEvent(i interface{}) {
-	EventRegistry[reflect.TypeOf(i).String()] = i
 }

--- a/vendor/github.com/codeamp/transistor/registry.go
+++ b/vendor/github.com/codeamp/transistor/registry.go
@@ -1,9 +1,15 @@
 package transistor
 
+import "reflect"
+
 type Creator func() Plugin
 
 var PluginRegistry = map[string]Creator{}
+var EventRegistry = make(map[string]interface{})
 
-func RegisterPlugin(name string, creator Creator) {
+func RegisterPlugin(name string, creator Creator, events ...interface{}) {
 	PluginRegistry[name] = creator
+	for _, i := range events {
+		EventRegistry[reflect.TypeOf(i).String()] = i
+	}
 }

--- a/vendor/github.com/codeamp/transistor/transistor.go
+++ b/vendor/github.com/codeamp/transistor/transistor.go
@@ -119,6 +119,9 @@ func (t *Transistor) addPlugin(name string) error {
 		e, _ := json.Marshal(message.Args())
 		event := Event{}
 		json.Unmarshal([]byte(e), &event)
+		if err := MapPayload(event.PayloadModel, &event); err != nil {
+			log.Fatal(fmt.Errorf("PayloadModel not found: %s. Did you add it to ApiRegistry?", event.PayloadModel))
+		}
 
 		//event.Dump()
 

--- a/vendor/github.com/codeamp/transistor/transistor.go
+++ b/vendor/github.com/codeamp/transistor/transistor.go
@@ -120,6 +120,7 @@ func (t *Transistor) addPlugin(name string) error {
 		event := Event{}
 		json.Unmarshal([]byte(e), &event)
 		if err := MapPayload(event.PayloadModel, &event); err != nil {
+			panic("need stack trace")
 			log.Fatal(fmt.Errorf("PayloadModel not found: %s. Did you add it to ApiRegistry?", event.PayloadModel))
 		}
 

--- a/vendor/github.com/codeamp/transistor/transistor.go
+++ b/vendor/github.com/codeamp/transistor/transistor.go
@@ -120,7 +120,6 @@ func (t *Transistor) addPlugin(name string) error {
 		event := Event{}
 		json.Unmarshal([]byte(e), &event)
 		if err := MapPayload(event.PayloadModel, &event); err != nil {
-			panic("need stack trace")
 			log.Fatal(fmt.Errorf("PayloadModel not found: %s. Did you add it to ApiRegistry?", event.PayloadModel))
 		}
 

--- a/vendor/github.com/codeamp/transistor/transistor.go
+++ b/vendor/github.com/codeamp/transistor/transistor.go
@@ -119,9 +119,6 @@ func (t *Transistor) addPlugin(name string) error {
 		e, _ := json.Marshal(message.Args())
 		event := Event{}
 		json.Unmarshal([]byte(e), &event)
-		if err := MapPayload(event.PayloadModel, &event); err != nil {
-			event.Error = fmt.Errorf("PayloadModel not found: %s. Did you add it to ApiRegistry?", event.PayloadModel)
-		}
 
 		//event.Dump()
 
@@ -181,11 +178,11 @@ func (t *Transistor) flusher() {
 			for _, plugin := range t.Plugins {
 				if plugin.Workers > 0 {
 					subscribedTo := plugin.Plugin.Subscribe()
-					if SliceContains(e.PayloadModel, subscribedTo) || SliceContains(e.Name, subscribedTo) {
+					if SliceContains(e.Event(), subscribedTo) {
 						ev_handled = true
 						if t.Config.Queueing {
-							log.InfoWithFields("Enqueue event", log.Fields{
-								"event_name":  e.Name,
+							log.DebugWithFields("Enqueue event", log.Fields{
+								"event_name":  e.Event(),
 								"plugin_name": plugin.Name,
 							})
 
@@ -208,7 +205,7 @@ func (t *Transistor) flusher() {
 			if t.TestEvents != nil {
 				t.TestEvents <- e
 			} else if !ev_handled {
-				log.InfoWithFields("Event not handled by any plugin", log.Fields{
+				log.WarnWithFields("Event not handled by any plugin", log.Fields{
 					"event_name": e.Name,
 				})
 				e.Dump()
@@ -297,7 +294,8 @@ func (t *Transistor) Stop() {
 }
 
 // GetTestEvent listens and returns requested event
-func (t *Transistor) GetTestEvent(name string, timeout time.Duration) Event {
+func (t *Transistor) GetTestEvent(name EventName, action Action, timeout time.Duration) Event {
+	eventName := fmt.Sprintf("%s:%s", name, action)
 	// timeout in the case that we don't get requested event
 	timer := time.NewTimer(time.Second * timeout)
 	go func() {
@@ -309,9 +307,9 @@ func (t *Transistor) GetTestEvent(name string, timeout time.Duration) Event {
 	}()
 
 	for e := range t.TestEvents {
-		matched, err := regexp.MatchString(name, e.Name)
+		matched, err := regexp.MatchString(eventName, e.Event())
 		if err != nil {
-			log.InfoWithFields("GetTestEvent regex match encountered an error", log.Fields{
+			log.ErrorWithFields("GetTestEvent regex match encountered an error", log.Fields{
 				"regex":  name,
 				"string": e.Name,
 				"error":  err,
@@ -322,12 +320,11 @@ func (t *Transistor) GetTestEvent(name string, timeout time.Duration) Event {
 			timer.Stop()
 			return e
 		}
-
-		log.DebugWithFields("GetTestEvent regex not matched", log.Fields{
-			"regex":  name,
-			"string": e.Name,
-		})
 	}
+
+	log.WarnWithFields("GetTestEvent regex not matched", log.Fields{
+		"regex": name,
+	})
 
 	return Event{}
 }

--- a/vendor/github.com/codeamp/transistor/utils.go
+++ b/vendor/github.com/codeamp/transistor/utils.go
@@ -1,7 +1,10 @@
 package transistor
 
 import (
+	"encoding/json"
+	"errors"
 	"math/rand"
+	"reflect"
 	"regexp"
 	"time"
 
@@ -44,4 +47,15 @@ func SliceContains(name string, list []string) bool {
 	})
 
 	return false
+}
+
+func MapPayload(name string, event *Event) error {
+	if typ, ok := EventRegistry[name]; ok {
+		d, _ := json.Marshal(event.Payload)
+		val := reflect.New(reflect.TypeOf(typ))
+		json.Unmarshal(d, val.Interface())
+		event.Payload = val.Elem().Interface()
+		return nil
+	}
+	return errors.New("no match")
 }

--- a/vendor/github.com/codeamp/transistor/utils.go
+++ b/vendor/github.com/codeamp/transistor/utils.go
@@ -1,10 +1,7 @@
 package transistor
 
 import (
-	"encoding/json"
-	"errors"
 	"math/rand"
-	"reflect"
 	"regexp"
 	"time"
 
@@ -35,23 +32,16 @@ func SliceContains(name string, list []string) bool {
 		if matched {
 			return true
 		}
-
-		log.DebugWithFields("SliceContains regex not matched", log.Fields{
-			"regex":  b,
-			"string": name,
-		})
 	}
+
+	// Moved outside of loop as this would return a debug log for every string that doesn't match
+	// regardless of if we found the match in the haystack or not.
+	// This way it only prints a debug if the regex didn't match ALL of the candidates
+	// ADB
+	log.DebugWithFields("SliceContains regex not matched", log.Fields{
+		"string": name,
+		"list":   list,
+	})
 
 	return false
-}
-
-func MapPayload(name string, event *Event) error {
-	if typ, ok := EventRegistry[name]; ok {
-		d, _ := json.Marshal(event.Payload)
-		val := reflect.New(reflect.TypeOf(typ))
-		json.Unmarshal(d, val.Interface())
-		event.Payload = val.Elem().Interface()
-		return nil
-	}
-	return errors.New("no match")
 }


### PR DESCRIPTION
This is a pretty heavy change.

Please review:
* Github Status plugin
* Mutation.go
* CodeAmp Plugin

Still yet to do:
* Adjust the ORM model for removed fields (state/statemessage)
* Adjust the seed data to not include removed fields
* Another pass of updating NewEvent calls to use transistor's event.Create() / event.Status() / etc.
* Update vendor folder for latest transistor edits  (could be done as part of https://github.com/codeamp/circuit/issues/194)

Fixes #198