### PR TITLE
Log format now supports json / is configurable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -101,7 +101,7 @@
   branch = "master"
   name = "github.com/codeamp/logger"
   packages = ["."]
-  revision = "3af44e5f22c2a3ace490347b8f65e51db8d28126"
+  revision = "0cff94f5cc2f062a76ac98a29c7de0c86c654334"
 
 [[projects]]
   branch = "master"
@@ -823,6 +823,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4acf39d3c174a6f2ec17f0e760f12719675a2e5d01a074f4fa59c9fd305115ef"
+  inputs-digest = "db420a28398ea784bb9f845fc97dfb51bffbbaa716512f2a6fb6086e05135231"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"strings"
+	"time"
 
 	log "github.com/codeamp/logger"
 	"github.com/sirupsen/logrus"
@@ -57,13 +58,24 @@ func initConfig() {
 		})
 	}
 
-	if _logLevel := viper.GetString("LOG_LEVEL"); _logLevel != "" {
-		logLevel, err := logrus.ParseLevel(_logLevel)
+	if _logLevel := viper.GetString("log_level"); _logLevel != "" {
+		logLevel, err := log.ParseLevel(_logLevel)
 
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		log.SetLogLevel(logLevel)
+	}
+
+	if logFormat := viper.GetString("log_format"); logFormat != "" {
+		switch strings.ToLower(logFormat) {
+		case "standard":
+			break
+		case "json":
+			fallthrough
+		default:
+			log.SetLogFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
+		}
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
         pull: 1
     environment:
       DOCKER_COMPOSE_POSTGRES_PORT: ${DOCKER_COMPOSE_POSTGRES_PORT}
+      CODEAMP_LOG_FORMAT: "standard"
     ports:
       - "${DOCKER_COMPOSE_CIRCUIT_PORT}:3011"
       - "${DOCKER_COMPOSE_DEX_PORT}:5556"

--- a/vendor/github.com/codeamp/logger/README.md
+++ b/vendor/github.com/codeamp/logger/README.md
@@ -1,4 +1,5 @@
-# Simple logrus wrapper
+# Logger [![CircleCI](https://circleci.com/gh/codeamp/logger.svg?style=svg)](https://circleci.com/gh/codeamp/logger) [![godoc](https://img.shields.io/badge/go-documentation-blue.svg)](https://godoc.org/github.com/codeamp/logger) [![Coverage Status](https://coveralls.io/repos/github/codeamp/logger/badge.svg?branch=master)](https://coveralls.io/github/codeamp/logger?branch=master) [![Go Report Card](https://goreportcard.com/badge/codeamp/logger)](https://goreportcard.com/report/codeamp/logger) [![codebeat badge](https://codebeat.co/badges/1c3bae3f-fb77-437e-93cb-7e07869898b5)](https://codebeat.co/projects/github-com-codeamp-logger-master)
+Simple logrus wrapper
 
 ### Example Usage
 ```
@@ -18,5 +19,3 @@ func main() {
   log.Debug("Hello World")
 }
 ```
-
-[GoDoc](https://godoc.org/github.com/codeamp/logger)

--- a/vendor/github.com/codeamp/logger/log.go
+++ b/vendor/github.com/codeamp/logger/log.go
@@ -29,6 +29,10 @@ func SetLogLevel(level logrus.Level) {
 	logger.Level = level
 }
 
+func ParseLevel(level string) (logrus.Level, error) {
+	return logrus.ParseLevel(level)
+}
+
 func SetLogFormatter(formatter logrus.Formatter) {
 	logger.Formatter = formatter
 }


### PR DESCRIPTION
Use the environment variable CODEAMP_LOG_FORMAT to set which format you would like.

It defaults to 'json' but you can set it to 'standard' to get the previous (apache?) log format.