### PR TITLE
TLC and fixes for tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -107,7 +107,7 @@
   branch = "master"
   name = "github.com/codeamp/transistor"
   packages = ["."]
-  revision = "2aed1d874103c833972c7526faaf303555b0bd54"
+  revision = "dce92d8d5551662bd5d772d0d6a73980bf0fe69f"
 
 [[projects]]
   branch = "master"
@@ -823,6 +823,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b4d0de6698558ea2ef0a3beef70c14bf3ae0735372dae1daf6768dfce013990b"
+  inputs-digest = "db420a28398ea784bb9f845fc97dfb51bffbbaa716512f2a6fb6086e05135231"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -1,15 +1,15 @@
 package dockerbuilder_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
+	"github.com/codeamp/circuit/plugins/dockerbuilder"
+	"github.com/codeamp/circuit/tests"
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -27,16 +27,9 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(viperConfig))
-
-	config := transistor.Config{
-		Plugins:        viper.GetStringMap("plugins"),
-		EnabledPlugins: []string{"dockerbuilder"},
-	}
-
-	ag, _ := transistor.NewTestTransistor(config)
-	suite.transistor = ag
+	suite.transistor, _ = tests.SetupPluginTest("dockerbuilder", viperConfig, func() transistor.Plugin {
+		return &dockerbuilder.DockerBuilder{}
+	})
 	go suite.transistor.Run()
 }
 
@@ -50,9 +43,9 @@ func (suite *TestSuite) TestDockerBuilder() {
 	deploytestHash := "4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9"
 
 	dockerBuildEvent := plugins.ReleaseExtension{
-		Slug: "dockerbuilder",
 		Release: plugins.Release{
 			Project: plugins.Project{
+				Slug:       "dockerbuilder",
 				Repository: "checkr/deploy-test",
 			},
 			Git: plugins.Git{
@@ -73,7 +66,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 		},
 	}
 
-	ev := transistor.NewEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("create"), dockerBuildEvent)
+	ev := transistor.NewEvent(plugins.GetEventName("dockerbuilder"), transistor.GetAction("create"), dockerBuildEvent)
 	ev.AddArtifact("USER", "test", false)
 	ev.AddArtifact("PASSWORD", "test", false)
 	ev.AddArtifact("EMAIL", "test@checkr.com", false)
@@ -81,13 +74,13 @@ func (suite *TestSuite) TestDockerBuilder() {
 	ev.AddArtifact("ORG", "testorg", false)
 	suite.transistor.Events <- ev
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 60)
-	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
-	assert.Equal(suite.T(), plugins.GetState("running"), e.State)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), transistor.GetAction("status"), 60)
+	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), transistor.GetState("running"), e.State)
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), plugins.GetAction("status"), 600)
-	assert.Equal(suite.T(), plugins.GetAction("status"), e.Action)
-	assert.Equal(suite.T(), plugins.GetState("complete"), e.State)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), transistor.GetAction("status"), 600)
+	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 
 	spew.Dump(e)
 	image, err := e.GetArtifact("image")

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/dockerbuilder"
-	"github.com/codeamp/circuit/tests"
+	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -24,7 +24,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = tests.SetupPluginTest("dockerbuilder", viperConfig, func() transistor.Plugin {
+	suite.transistor, _ = test.SetupPluginTest("dockerbuilder", viperConfig, func() transistor.Plugin {
 		return &dockerbuilder.DockerBuilder{Socket: "unix:///var/run/docker.sock"}
 	})
 	go suite.transistor.Run()

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -24,9 +24,13 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = test.SetupPluginTest("dockerbuilder", viperConfig, func() transistor.Plugin {
-		return &dockerbuilder.DockerBuilder{Socket: "unix:///var/run/docker.sock"}
-	})
+	creatorsMap := map[string]transistor.Creator{
+		"dockerbuilder": func() transistor.Plugin {
+			return &dockerbuilder.DockerBuilder{Socket: "unix:///var/run/docker.sock"}
+		},
+	}
+
+	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
 	go suite.transistor.Run()
 }
 

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -6,10 +6,7 @@ import (
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/dockerbuilder"
 	"github.com/codeamp/circuit/tests"
-	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -28,7 +25,7 @@ plugins:
 
 func (suite *TestSuite) SetupSuite() {
 	suite.transistor, _ = tests.SetupPluginTest("dockerbuilder", viperConfig, func() transistor.Plugin {
-		return &dockerbuilder.DockerBuilder{}
+		return &dockerbuilder.DockerBuilder{Socket: "unix:///var/run/docker.sock"}
 	})
 	go suite.transistor.Run()
 }
@@ -39,7 +36,7 @@ func (suite *TestSuite) TearDownSuite() {
 
 func (suite *TestSuite) TestDockerBuilder() {
 	var e transistor.Event
-	log.SetLogLevel(logrus.DebugLevel)
+	var err error
 	deploytestHash := "4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9"
 
 	dockerBuildEvent := plugins.ReleaseExtension{
@@ -66,7 +63,7 @@ func (suite *TestSuite) TestDockerBuilder() {
 		},
 	}
 
-	ev := transistor.NewEvent(plugins.GetEventName("dockerbuilder"), transistor.GetAction("create"), dockerBuildEvent)
+	ev := transistor.NewEvent(plugins.GetEventName("release:dockerbuilder"), transistor.GetAction("create"), dockerBuildEvent)
 	ev.AddArtifact("USER", "test", false)
 	ev.AddArtifact("PASSWORD", "test", false)
 	ev.AddArtifact("EMAIL", "test@checkr.com", false)
@@ -74,21 +71,33 @@ func (suite *TestSuite) TestDockerBuilder() {
 	ev.AddArtifact("ORG", "testorg", false)
 	suite.transistor.Events <- ev
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), transistor.GetAction("status"), 60)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("release:dockerbuilder"), transistor.GetAction("status"), 60)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error)
+		return
+	}
 	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), transistor.GetState("running"), e.State)
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("dockerbuilder"), transistor.GetAction("status"), 600)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("release:dockerbuilder"), transistor.GetAction("status"), 600)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error)
+		return
+	}
 	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 
-	spew.Dump(e)
-	image, err := e.GetArtifact("image")
-	if err != nil {
-		log.Fatal(err)
+	if e.State == transistor.GetState("failed") {
+		suite.T().Log(e.StateMessage)
+		return
 	}
 
-	assert.Equal(suite.T(), image.String(), "0.0.0.0:5000/testorg/checkr-deploy-test:4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9.testing")
+	image, err := e.GetArtifact("image")
+	assert.Nil(suite.T(), err)
+
+	if err == nil {
+		assert.Equal(suite.T(), image.String(), "0.0.0.0:5000/testorg/checkr-deploy-test:4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9.testing")
+	}
 }
 
 func TestDockerBuilder(t *testing.T) {

--- a/plugins/dockerbuilder/dockerbuilder_test.go
+++ b/plugins/dockerbuilder/dockerbuilder_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
-	"github.com/codeamp/circuit/plugins/dockerbuilder"
+	_ "github.com/codeamp/circuit/plugins/dockerbuilder"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
@@ -24,13 +24,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	creatorsMap := map[string]transistor.Creator{
-		"dockerbuilder": func() transistor.Plugin {
-			return &dockerbuilder.DockerBuilder{Socket: "unix:///var/run/docker.sock"}
-		},
-	}
-
-	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
+	suite.transistor, _ = test.SetupPluginTest(viperConfig)
 	go suite.transistor.Run()
 }
 

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -20,6 +20,7 @@ func GetEventName(s string) transistor.EventName {
 		"gitsync",
 		"gitsync:commit",
 		"heartbeat",
+		"release",
 		"project:dockerbuilder",
 		"release:dockerbuilder",
 		"route53",

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -11,16 +11,18 @@ import (
 
 func GetEventName(s string) transistor.EventName {
 	eventNames := []string{
-		"kubernetes:deployment",
-		"kubernetes:loadbalancer",
-		"githubstatus",
+		"project:kubernetes:deployment",
+		"release:kubernetes:deployment",
+		"project:kubernetes:loadbalancer",
+		"release:kubernetes:loadbalancer",
+		"project:githubstatus",
+		"release:githubstatus",
 		"gitsync",
 		"gitsync:commit",
 		"heartbeat",
-		"dockerbuilder",
+		"project:dockerbuilder",
+		"release:dockerbuilder",
 		"route53",
-		"release",
-		"project",
 		"websocket",
 	}
 

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/githubstatus"
-	"github.com/codeamp/circuit/tests"
+	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -25,7 +25,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = tests.SetupPluginTest("githubstatus", viperConfig, func() transistor.Plugin {
+	suite.transistor, _ = test.SetupPluginTest("githubstatus", viperConfig, func() transistor.Plugin {
 		return &githubstatus.GithubStatus{}
 	})
 	go suite.transistor.Run()

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -3,14 +3,11 @@ package githubstatus_test
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/githubstatus"
 	"github.com/codeamp/circuit/tests"
-	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	httpmock "gopkg.in/jarcoal/httpmock.v1"
@@ -39,21 +36,13 @@ func (suite *TestSuite) TearDownSuite() {
 }
 
 func (suite *TestSuite) TestGithubStatus() {
-	timer := time.NewTimer(time.Second * 120)
-	defer timer.Stop()
-
-	go func() {
-		<-timer.C
-		log.Fatal("TestGithubStatus: Test timeout")
-	}()
-
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
 	deploytestHash := "4930db36d9ef6ef4e6a986b6db2e40ec477c7bc9"
 
 	var e transistor.Event
-	log.SetLogLevel(logrus.DebugLevel)
+	var err error
 
 	githubStatusPayload := plugins.ReleaseExtension{
 		Release: plugins.Release{
@@ -138,7 +127,7 @@ func (suite *TestSuite) TestGithubStatus() {
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusPayload.Release.Project.Repository, githubStatusPayload.Release.HeadFeature.Hash),
 		httpmock.NewStringResponder(200, githubRunningStatusResponse))
 
-	ev := transistor.NewEvent(plugins.GetEventName("githubstatus"), transistor.GetAction("create"), githubStatusPayload)
+	ev := transistor.NewEvent(plugins.GetEventName("release:githubstatus"), transistor.GetAction("create"), githubStatusPayload)
 	ev.AddArtifact("timeout_seconds", "100", false)
 	ev.AddArtifact("timeout_interval", "5", false)
 	ev.AddArtifact("personal_access_token", "test", false)
@@ -146,18 +135,26 @@ func (suite *TestSuite) TestGithubStatus() {
 
 	suite.transistor.Events <- ev
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("githubstatus"), transistor.GetAction("status"), 10)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("release:githubstatus"), transistor.GetAction("status"), 10)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error)
+		return
+	}
 	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), transistor.GetState("running"), e.State)
 
 	httpmock.RegisterResponder("GET", fmt.Sprintf("https://api.github.com/repos/%s/commits/%s/status", githubStatusPayload.Release.Project.Repository, githubStatusPayload.Release.HeadFeature.Hash),
 		httpmock.NewStringResponder(200, githubSuccessStatusResponse))
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("githubstatus"), transistor.GetAction("status"), 10)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("release:githubstatus"), transistor.GetAction("status"), 10)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error)
+		return
+	}
 	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 }
 
-func TestDockerBuilder(t *testing.T) {
+func TestGithubStatus(t *testing.T) {
 	suite.Run(t, new(TestSuite))
 }

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
-	"github.com/codeamp/circuit/plugins/githubstatus"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
@@ -25,13 +24,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	creatorsMap := map[string]transistor.Creator{
-		"githubstatus": func() transistor.Plugin {
-			return &githubstatus.GithubStatus{}
-		},
-	}
-
-	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
+	suite.transistor, _ = test.SetupPluginTest(viperConfig)
 	go suite.transistor.Run()
 }
 

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -25,9 +25,13 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = test.SetupPluginTest("githubstatus", viperConfig, func() transistor.Plugin {
-		return &githubstatus.GithubStatus{}
-	})
+	creatorsMap := map[string]transistor.Creator{
+		"githubstatus": func() transistor.Plugin {
+			return &githubstatus.GithubStatus{}
+		},
+	}
+
+	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
 	go suite.transistor.Run()
 }
 

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -24,9 +24,13 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = test.SetupPluginTest("gitsync", viperConfig, func() transistor.Plugin {
-		return &gitsync.GitSync{}
-	})
+	creatorsMap := map[string]transistor.Creator{
+		"gitsync": func() transistor.Plugin {
+			return &gitsync.GitSync{}
+		},
+	}
+
+	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
 	go suite.transistor.Run()
 }
 

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
-	"github.com/codeamp/circuit/plugins/gitsync"
+	_ "github.com/codeamp/circuit/plugins/gitsync"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
@@ -24,13 +24,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	creatorsMap := map[string]transistor.Creator{
-		"gitsync": func() transistor.Plugin {
-			return &gitsync.GitSync{}
-		},
-	}
-
-	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
+	suite.transistor, _ = test.SetupPluginTest(viperConfig)
 	go suite.transistor.Run()
 }
 

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/gitsync"
-	"github.com/codeamp/circuit/tests"
+	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -24,7 +24,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = tests.SetupPluginTest("gitsync", viperConfig, func() transistor.Plugin {
+	suite.transistor, _ = test.SetupPluginTest("gitsync", viperConfig, func() transistor.Plugin {
 		return &gitsync.GitSync{}
 	})
 	go suite.transistor.Run()

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -1,13 +1,12 @@
 package gitsync_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/gitsync"
+	"github.com/codeamp/circuit/tests"
 	"github.com/codeamp/transistor"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -25,20 +24,9 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(viperConfig))
-
-	config := transistor.Config{
-		Plugins:        viper.GetStringMap("plugins"),
-		EnabledPlugins: []string{"gitsync"},
-	}
-
-	transistor.RegisterPlugin("gitsync", func() transistor.Plugin {
+	suite.transistor, _ = tests.SetupPluginTest("gitsync", viperConfig, func() transistor.Plugin {
 		return &gitsync.GitSync{}
 	})
-
-	ag, _ := transistor.NewTestTransistor(config)
-	suite.transistor = ag
 	go suite.transistor.Run()
 }
 
@@ -63,14 +51,14 @@ func (suite *TestSuite) TestGitSync() {
 		From: "",
 	}
 
-	event := transistor.NewEvent(plugins.GetEventName("gitsync"), plugins.GetAction("create"), gitSync)
+	event := transistor.NewEvent(plugins.GetEventName("gitsync"), transistor.GetAction("create"), gitSync)
 	suite.transistor.Events <- event
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), plugins.GetAction("status"), 30)
-	assert.Equal(suite.T(), e.State, plugins.GetState("fetching"))
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), transistor.GetAction("status"), 30)
+	assert.Equal(suite.T(), e.State, transistor.GetState("running"))
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), plugins.GetAction("status"), 30)
-	assert.Equal(suite.T(), e.State, plugins.GetState("complete"))
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), transistor.GetAction("status"), 30)
+	assert.Equal(suite.T(), e.State, transistor.GetState("complete"))
 	assert.NotNil(suite.T(), e.Payload.(plugins.GitSync).Commits)
 	assert.NotEqual(suite.T(), 0, len(e.Payload.(plugins.GitSync).Commits), "commits should not be empty")
 }

--- a/plugins/gitsync/gitsync_test.go
+++ b/plugins/gitsync/gitsync_test.go
@@ -36,6 +36,7 @@ func (suite *TestSuite) TearDownSuite() {
 
 func (suite *TestSuite) TestGitSync() {
 	var e transistor.Event
+	var err error
 
 	gitSync := plugins.GitSync{
 		Project: plugins.Project{
@@ -54,10 +55,18 @@ func (suite *TestSuite) TestGitSync() {
 	event := transistor.NewEvent(plugins.GetEventName("gitsync"), transistor.GetAction("create"), gitSync)
 	suite.transistor.Events <- event
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), transistor.GetAction("status"), 30)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), transistor.GetAction("status"), 30)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error())
+		return
+	}
 	assert.Equal(suite.T(), e.State, transistor.GetState("running"))
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), transistor.GetAction("status"), 30)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("gitsync"), transistor.GetAction("status"), 30)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error())
+		return
+	}
 	assert.Equal(suite.T(), e.State, transistor.GetState("complete"))
 	assert.NotNil(suite.T(), e.Payload.(plugins.GitSync).Commits)
 	assert.NotEqual(suite.T(), 0, len(e.Payload.(plugins.GitSync).Commits), "commits should not be empty")

--- a/plugins/heartbeat/heartbeat.go
+++ b/plugins/heartbeat/heartbeat.go
@@ -14,6 +14,7 @@ type Heartbeat struct {
 }
 
 func init() {
+	log.Error("init from heartbeat")
 	transistor.RegisterPlugin("heartbeat", func() transistor.Plugin {
 		return &Heartbeat{}
 	})

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -35,8 +35,13 @@ func (suite *TestSuite) TearDownSuite() {
 
 func (suite *TestSuite) TestHeartbeat() {
 	var e transistor.Event
+	var err error
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), transistor.GetAction("status"), 61)
+	e, err = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), transistor.GetAction("status"), 61)
+	if err != nil {
+		assert.Nil(suite.T(), err, err.Error())
+		return
+	}
 	payload := e.Payload.(plugins.HeartBeat)
 	assert.Equal(suite.T(), "minute", payload.Tick)
 }

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
-	"github.com/codeamp/circuit/plugins/heartbeat"
+	_ "github.com/codeamp/circuit/plugins/heartbeat"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
@@ -23,13 +23,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	creatorsMap := map[string]transistor.Creator{
-		"heartbeat": func() transistor.Plugin {
-			return &heartbeat.Heartbeat{}
-		},
-	}
-
-	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
+	suite.transistor, _ = test.SetupPluginTest(viperConfig)
 	go suite.transistor.Run()
 }
 

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -1,13 +1,12 @@
 package heartbeat_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/heartbeat"
+	"github.com/codeamp/circuit/tests"
 	"github.com/codeamp/transistor"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -24,19 +23,9 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	viper.SetConfigType("yaml")
-	viper.ReadConfig(bytes.NewBuffer(viperConfig))
-
-	transistor.RegisterPlugin("heartbeat", func() transistor.Plugin {
+	suite.transistor, _ = tests.SetupPluginTest("heartbeat", viperConfig, func() transistor.Plugin {
 		return &heartbeat.Heartbeat{}
 	})
-
-	config := transistor.Config{
-		Plugins:        viper.GetStringMap("plugins"),
-		EnabledPlugins: []string{"heartbeat"},
-	}
-	ag, _ := transistor.NewTestTransistor(config)
-	suite.transistor = ag
 	go suite.transistor.Run()
 }
 
@@ -47,7 +36,7 @@ func (suite *TestSuite) TearDownSuite() {
 func (suite *TestSuite) TestHeartbeat() {
 	var e transistor.Event
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), plugins.GetAction("status"), 61)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("heartbeat"), transistor.GetAction("status"), 61)
 	payload := e.Payload.(plugins.HeartBeat)
 	assert.Equal(suite.T(), "minute", payload.Tick)
 }

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -23,9 +23,13 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = test.SetupPluginTest("heartbeat", viperConfig, func() transistor.Plugin {
-		return &heartbeat.Heartbeat{}
-	})
+	creatorsMap := map[string]transistor.Creator{
+		"heartbeat": func() transistor.Plugin {
+			return &heartbeat.Heartbeat{}
+		},
+	}
+
+	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
 	go suite.transistor.Run()
 }
 

--- a/plugins/heartbeat/heartbeat_test.go
+++ b/plugins/heartbeat/heartbeat_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/heartbeat"
-	"github.com/codeamp/circuit/tests"
+	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -23,7 +23,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = tests.SetupPluginTest("heartbeat", viperConfig, func() transistor.Plugin {
+	suite.transistor, _ = test.SetupPluginTest("heartbeat", viperConfig, func() transistor.Plugin {
 		return &heartbeat.Heartbeat{}
 	})
 	go suite.transistor.Run()

--- a/plugins/kubernetes/kubernetes_test.go
+++ b/plugins/kubernetes/kubernetes_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/kubernetes"
-	"github.com/codeamp/circuit/tests"
+	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -29,7 +29,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = tests.SetupPluginTest("kubernetes", viperConfig, func() transistor.Plugin {
+	suite.transistor, _ = test.SetupPluginTest("kubernetes", viperConfig, func() transistor.Plugin {
 		return &kubernetes.Kubernetes{}
 	})
 

--- a/plugins/kubernetes/kubernetes_test.go
+++ b/plugins/kubernetes/kubernetes_test.go
@@ -1,7 +1,6 @@
 package kubernetes_test
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -13,9 +12,9 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/plugins/kubernetes"
+	"github.com/codeamp/circuit/tests"
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -32,32 +31,19 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	viper.SetConfigType("YAML")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.SetEnvPrefix("CODEAMP")
-	viper.AutomaticEnv()
-	viper.ReadConfig(bytes.NewBuffer(viperConfig))
-
-	transistor.RegisterPlugin("kubernetes", func() transistor.Plugin {
+	suite.transistor, _ = tests.SetupPluginTest("kubernetes", viperConfig, func() transistor.Plugin {
 		return &kubernetes.Kubernetes{}
 	})
 
-	config := transistor.Config{
-		Plugins:        viper.GetStringMap("plugins"),
-		EnabledPlugins: []string{"kubernetes"},
-	}
-
-	ag, _ := transistor.NewTestTransistor(config)
-	suite.transistor = ag
 	go suite.transistor.Run()
 }
 
 // Load Balancers Tests
 func (suite *TestSuite) TestCleanupLBOffice() {
-	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("delete"), plugins.GetType("office"))
+	suite.transistor.Events <- LBTCPEvent(transistor.GetAction("delete"), plugins.GetType("office"))
 
-	e := suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), plugins.GetAction("status"), 60)
-	assert.Equal(suite.T(), plugins.GetState("deleted"), e.State, e.StateMessage)
+	e := suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), transistor.GetAction("status"), 60)
+	assert.Equal(suite.T(), transistor.GetState("deleted"), e.State, e.StateMessage)
 }
 
 func (suite *TestSuite) TestLBTCPOffice() {
@@ -69,26 +55,26 @@ func (suite *TestSuite) TestLBTCPOffice() {
 		log.Fatal("TestLBTCPOffice: Test timeout")
 	}()
 
-	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("update"), plugins.GetType("office"))
+	suite.transistor.Events <- LBTCPEvent(transistor.GetAction("update"), plugins.GetType("office"))
 
 	var e transistor.Event
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), plugins.GetAction("status"), 120)
-	assert.Equal(suite.T(), plugins.GetState("complete"), e.State, e.StateMessage)
-	if e.State != plugins.GetState("complete") {
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), transistor.GetAction("status"), 120)
+	assert.Equal(suite.T(), transistor.GetState("complete"), e.State, e.StateMessage)
+	if e.State != transistor.GetState("complete") {
 		return
 	}
 
 	for {
-		e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), plugins.GetAction("status"), 120)
+		e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), transistor.GetAction("status"), 120)
 		if e.State != "running" {
 			break
 		}
 	}
 
-	suite.transistor.Events <- LBTCPEvent(plugins.GetAction("delete"), plugins.GetType("office"))
+	suite.transistor.Events <- LBTCPEvent(transistor.GetAction("delete"), plugins.GetType("office"))
 
-	e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), plugins.GetAction("status"), 10)
-	assert.Equal(suite.T(), plugins.GetState("deleted"), e.State)
+	e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:loadbalancer"), transistor.GetAction("status"), 10)
+	assert.Equal(suite.T(), transistor.GetState("deleted"), e.State)
 }
 
 func strMapKeys(strMap map[string]string) string {
@@ -117,14 +103,14 @@ func (suite *TestSuite) TestBasicSuccessDeploy() {
 
 	var e transistor.Event
 	for {
-		e = suite.transistor.GetTestEvent("kubernetes:deployment", plugins.GetAction("status"), 30)
+		e = suite.transistor.GetTestEvent("kubernetes:deployment", transistor.GetAction("status"), 30)
 		if e.State != "running" {
 			break
 		}
 	}
 
 	suite.T().Log(e.StateMessage)
-	assert.Equal(suite.T(), plugins.GetState("complete"), e.State)
+	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 }
 
 func (suite *TestSuite) TestBasicFailedDeploy() {
@@ -140,14 +126,14 @@ func (suite *TestSuite) TestBasicFailedDeploy() {
 
 	var e transistor.Event
 	for {
-		e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("status"), 30)
+		e = suite.transistor.GetTestEvent(plugins.GetEventName("kubernetes:deployment"), transistor.GetAction("status"), 30)
 		if e.State != "running" {
 			break
 		}
 	}
 
 	suite.T().Log(e.StateMessage)
-	assert.Equal(suite.T(), plugins.GetState("failed"), e.State)
+	assert.Equal(suite.T(), transistor.GetState("failed"), e.State)
 }
 
 func TestDeployments(t *testing.T) {
@@ -202,7 +188,7 @@ func verifyDeploymentArtifacts() error {
 }
 
 func verifyLoadBalancerArtifacts() error {
-	e := LBTCPEvent(plugins.GetAction("update"), plugins.GetType("office"))
+	e := LBTCPEvent(transistor.GetAction("update"), plugins.GetType("office"))
 
 	lbTCPArtifacts := map[string]string{
 		"service":               "",
@@ -234,7 +220,7 @@ func LBDataForTCP(action transistor.Action, t plugins.Type) plugins.ProjectExten
 	}
 
 	lbe := plugins.ProjectExtension{
-		Slug:        "kubernetesloadbalancers",
+		//		Slug:        "kubernetesloadbalancers",
 		Environment: "testing",
 		Project:     project,
 		ID:          "nginx-test-lb-asdf1234",
@@ -281,7 +267,7 @@ func BasicFailedReleaseEvent() transistor.Event {
 	extension := BasicReleaseExtension()
 	extension.Release.Services[0].Command = "/bin/false"
 
-	event := transistor.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("create"), extension)
+	event := transistor.NewEvent(plugins.GetEventName("kubernetes:deployment"), transistor.GetAction("create"), extension)
 	addBasicReleaseExtensionArtifacts(extension, &event)
 
 	return event
@@ -310,7 +296,7 @@ func addBasicReleaseExtensionArtifacts(extension plugins.ReleaseExtension, event
 func BasicReleaseEvent() transistor.Event {
 	extension := BasicReleaseExtension()
 
-	event := transistor.NewEvent(plugins.GetEventName("kubernetes:deployment"), plugins.GetAction("create"), extension)
+	event := transistor.NewEvent(plugins.GetEventName("kubernetes:deployment"), transistor.GetAction("create"), extension)
 	addBasicReleaseExtensionArtifacts(extension, &event)
 
 	return event
@@ -341,7 +327,7 @@ func BasicReleaseExtension() plugins.ReleaseExtension {
 						Protocol: "TCP",
 					},
 				},
-				State: plugins.GetState("waiting"),
+				State: transistor.GetState("waiting"),
 				Spec: plugins.ServiceSpec{
 
 					CpuRequest:                    "10m",
@@ -363,7 +349,7 @@ func BasicReleaseExtension() plugins.ReleaseExtension {
 	}
 
 	releaseExtension := plugins.ReleaseExtension{
-		Slug:    "kubernetesdeployments",
+		//		Slug:    "kubernetesdeployments",
 		Release: release,
 	}
 

--- a/plugins/kubernetes/kubernetes_test.go
+++ b/plugins/kubernetes/kubernetes_test.go
@@ -29,10 +29,13 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	suite.transistor, _ = test.SetupPluginTest("kubernetes", viperConfig, func() transistor.Plugin {
-		return &kubernetes.Kubernetes{}
-	})
+	creatorsMap := map[string]transistor.Creator{
+		"kubernetes": func() transistor.Plugin {
+			return &kubernetes.Kubernetes{}
+		},
+	}
 
+	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
 	go suite.transistor.Run()
 }
 

--- a/plugins/kubernetes/kubernetes_test.go
+++ b/plugins/kubernetes/kubernetes_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
-	"github.com/codeamp/circuit/plugins/kubernetes"
+	_ "github.com/codeamp/circuit/plugins/kubernetes"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
@@ -29,13 +29,7 @@ plugins:
 `)
 
 func (suite *TestSuite) SetupSuite() {
-	creatorsMap := map[string]transistor.Creator{
-		"kubernetes": func() transistor.Plugin {
-			return &kubernetes.Kubernetes{}
-		},
-	}
-
-	suite.transistor, _ = test.SetupPluginTest(viperConfig, creatorsMap)
+	suite.transistor, _ = test.SetupPluginTest(viperConfig)
 	go suite.transistor.Run()
 }
 

--- a/test/test.go
+++ b/test/test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"bytes"

--- a/test/test.go
+++ b/test/test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-func SetupPluginTest(viperConfig []byte, creatorsMap map[string]transistor.Creator) (*transistor.Transistor, error) {
+func SetupPluginTest(viperConfig []byte) (*transistor.Transistor, error) {
 	setupViperConfig(viperConfig)
 
 	pluginConfig := viper.GetStringMap("plugins")

--- a/test/test.go
+++ b/test/test.go
@@ -11,23 +11,19 @@ import (
 	"github.com/spf13/viper"
 )
 
-func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.Creator) (*transistor.Transistor, error) {
-	pluginMap := map[string]transistor.Creator{pluginName: creator}
-	return SetupMultiPluginTest(viperConfig, pluginMap)
-}
-
-func SetupMultiPluginTest(viperConfig []byte, creatorsMap map[string]transistor.Creator) (*transistor.Transistor, error) {
+func SetupPluginTest(viperConfig []byte, creatorsMap map[string]transistor.Creator) (*transistor.Transistor, error) {
 	setupViperConfig(viperConfig)
 
-	enabledPlugins := make([]string, 1, 1)
-	for pluginName, creator := range creatorsMap {
-		transistor.RegisterPlugin(pluginName, creator)
-		enabledPlugins = append(enabledPlugins, pluginName)
+	pluginConfig := viper.GetStringMap("plugins")
+	enabledPluginNames := make([]string, 0, len(pluginConfig))
+
+	for pluginName, _ := range pluginConfig {
+		enabledPluginNames = append(enabledPluginNames, pluginName)
 	}
 
 	config := transistor.Config{
-		Plugins:        viper.GetStringMap("plugins"),
-		EnabledPlugins: enabledPlugins,
+		Plugins:        pluginConfig,
+		EnabledPlugins: enabledPluginNames,
 	}
 
 	configLogLevel()

--- a/test/test.go
+++ b/test/test.go
@@ -12,12 +12,22 @@ import (
 )
 
 func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.Creator) (*transistor.Transistor, error) {
+	pluginMap := map[string]transistor.Creator{pluginName: creator}
+	return SetupMultiPluginTest(viperConfig, pluginMap)
+}
+
+func SetupMultiPluginTest(viperConfig []byte, creatorsMap map[string]transistor.Creator) (*transistor.Transistor, error) {
 	setupViperConfig(viperConfig)
-	transistor.RegisterPlugin(pluginName, creator)
+
+	enabledPlugins := make([]string, 1, 1)
+	for pluginName, creator := range creatorsMap {
+		transistor.RegisterPlugin(pluginName, creator)
+		enabledPlugins = append(enabledPlugins, pluginName)
+	}
 
 	config := transistor.Config{
 		Plugins:        viper.GetStringMap("plugins"),
-		EnabledPlugins: []string{pluginName},
+		EnabledPlugins: enabledPlugins,
 	}
 
 	configLogLevel()

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -3,8 +3,11 @@ package tests
 import (
 	"bytes"
 	"strings"
+	"time"
 
+	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -20,6 +23,27 @@ func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.C
 	config := transistor.Config{
 		Plugins:        viper.GetStringMap("plugins"),
 		EnabledPlugins: []string{pluginName},
+	}
+
+	if _logLevel := viper.GetString("log_level"); _logLevel != "" {
+		logLevel, err := log.ParseLevel(_logLevel)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		log.SetLogLevel(logLevel)
+	}
+
+	if logFormat := viper.GetString("log_format"); logFormat != "" {
+		switch strings.ToLower(logFormat) {
+		case "standard":
+			break
+		case "json":
+			fallthrough
+		default:
+			log.SetLogFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
+		}
 	}
 
 	return transistor.NewTestTransistor(config)

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -1,0 +1,26 @@
+package tests
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/codeamp/transistor"
+	"github.com/spf13/viper"
+)
+
+func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.Creator) (*transistor.Transistor, error) {
+	viper.SetConfigType("yaml")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvPrefix("CODEAMP")
+	viper.AutomaticEnv()
+	viper.ReadConfig(bytes.NewBuffer(viperConfig))
+
+	transistor.RegisterPlugin(pluginName, creator)
+
+	config := transistor.Config{
+		Plugins:        viper.GetStringMap("plugins"),
+		EnabledPlugins: []string{pluginName},
+	}
+
+	return transistor.NewTestTransistor(config)
+}

--- a/tests/tests.go
+++ b/tests/tests.go
@@ -12,12 +12,7 @@ import (
 )
 
 func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.Creator) (*transistor.Transistor, error) {
-	viper.SetConfigType("yaml")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
-	viper.SetEnvPrefix("CODEAMP")
-	viper.AutomaticEnv()
-	viper.ReadConfig(bytes.NewBuffer(viperConfig))
-
+	setupViperConfig(viperConfig)
 	transistor.RegisterPlugin(pluginName, creator)
 
 	config := transistor.Config{
@@ -25,6 +20,22 @@ func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.C
 		EnabledPlugins: []string{pluginName},
 	}
 
+	configLogLevel()
+	configLogFormat()
+
+	return transistor.NewTestTransistor(config)
+}
+
+func setupViperConfig(viperConfig []byte) {
+	viper.SetConfigType("yaml")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvPrefix("CODEAMP")
+	viper.AutomaticEnv()
+
+	viper.ReadConfig(bytes.NewBuffer(viperConfig))
+}
+
+func configLogLevel() {
 	if _logLevel := viper.GetString("log_level"); _logLevel != "" {
 		logLevel, err := log.ParseLevel(_logLevel)
 
@@ -34,7 +45,9 @@ func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.C
 
 		log.SetLogLevel(logLevel)
 	}
+}
 
+func configLogFormat() {
 	if logFormat := viper.GetString("log_format"); logFormat != "" {
 		switch strings.ToLower(logFormat) {
 		case "standard":
@@ -45,6 +58,4 @@ func SetupPluginTest(pluginName string, viperConfig []byte, creator transistor.C
 			log.SetLogFormatter(&logrus.JSONFormatter{TimestampFormat: time.RFC3339Nano})
 		}
 	}
-
-	return transistor.NewTestTransistor(config)
 }


### PR DESCRIPTION
* Consolidated plugins tests setup into a `test.SetupPluginTest` function.
This handles log level and log format now and loading/registering plugins for tests.
* Updated plugin tests to use `transistor.GetState` as opposed to `plugins.GetState`
* Transistor Update: GetTestEvent returns an error now instead of issuing a panic after a timeout
Tests can now handle the timeout situation on their own.

Fixes #218