### PR TITLE
create POD_IP env var from status metadata

### DIFF
--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -365,6 +365,18 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 		}
 	}
 
+	// create env var for pod ip, constructed from pod metadata on deploy
+	podIPEnvVar := v1.EnvVar{
+		Name: "POD_IP",
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{
+				FieldPath: "status.podIP",
+			},
+		},
+	}
+
+	myEnvVars = append(myEnvVars, podIPEnvVar)
+
 	// as Files
 	var volumeMounts []v1.VolumeMount
 	var deployVolumes []v1.Volume


### PR DESCRIPTION
This environment variable is required by some pods which utilize agent/master architectures in order to register accurate IPs.

e.g. gravitational teleport.

I'm not really a fan of how rigid this implementation is, however we handle all other environment variables as secrets where the value is known prior to creating the spec in kubernetes. Some values (like pod ip) are computed during run time.