### PR TITLE
Expose pod info to running container for metrics reporting purposes

### DIFF
--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -725,7 +725,7 @@ func (x *Kubernetes) doDeploy(e transistor.Event) error {
 			return err
 		}
 
-		// expose service name via env variable
+		// expose codeamp service name via env variable
 		podEnvVars := append(myEnvVars, v1.EnvVar{
 			Name:  "CODEAMP_SERVICE_NAME",
 			Value: service.Name,


### PR DESCRIPTION
Four env variables exposed:
- MY_NODE_NAME
- MY_POD_NAME
- MY_POD_NAMESPACE
- MY_SERVICE_NAME

The first three are exposed via Kubernetes downward API:
https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

The last one is directly exposed as name-value pair.