### PR TITLE
Add ProjectSettings object when adding ProjectEnvironments

### DIFF
--- a/plugins/codeamp/graphql/mutation.go
+++ b/plugins/codeamp/graphql/mutation.go
@@ -1424,6 +1424,11 @@ func (r *Resolver) UpdateProjectEnvironments(ctx context.Context, args *struct {
 				ProjectID:     project.Model.ID,
 			}
 			r.DB.Where("environment_id = ? and project_id = ?", environment.Model.ID, project.Model.ID).FirstOrCreate(&projectEnvironment)
+			r.DB.Create(&model.ProjectSettings{
+				EnvironmentID: environment.Model.ID,
+				ProjectID:     project.Model.ID,
+				GitBranch:     "master",
+			})
 			results = append(results, &EnvironmentResolver{DBEnvironmentResolver: &db_resolver.EnvironmentResolver{DB: r.DB, Environment: environment}})
 		} else {
 			r.DB.Where("environment_id = ? and project_id = ?", environment.Model.ID, project.Model.ID).Delete(&model.ProjectEnvironment{})


### PR DESCRIPTION
Add missing DB objects when provisioning envs for a project

<!--- Provide a general summary of your changes in the Title above -->

## Description
Create a ProjectSettings object for each requested environment for a project in `UpdateProjectEnvironments`.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
People are not able to deploy projects on new environments. 

Reproduce by:

1. Provision new environment for a project
2. Deploy project in the new environment with DockerBuilder installed.
3. Click on release and view error.

## Screenshots (if appropriate):
<img width="518" alt="screenshot 2018-06-29 11 43 22" src="https://user-images.githubusercontent.com/3188413/42109183-a54cceac-7b91-11e8-99da-e3920e2c89b7.png">

## How Has This Been Tested?
This PR doesn't have tests, but the corresponding
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->