### PR TITLE
Provision default envs for project on creation and remove envID param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p $APP_PATH
 WORKDIR $APP_PATH
 COPY . $APP_PATH
 
+RUN go get github.com/cespare/reflex
 RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN mkdir -p assets/
 RUN /go/bin/go-bindata -pkg assets -o assets/assets.go plugins/codeamp/graphql/schema.graphql

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN mkdir -p $APP_PATH
 WORKDIR $APP_PATH
 COPY . $APP_PATH
 
-RUN go get github.com/cespare/reflex
 RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN mkdir -p assets/
 RUN /go/bin/go-bindata -pkg assets -o assets/assets.go plugins/codeamp/graphql/schema.graphql

--- a/plugins/codeamp/graphql/helpers_test.go
+++ b/plugins/codeamp/graphql/helpers_test.go
@@ -69,11 +69,9 @@ func (helper *Helper) CreateProject(t *testing.T, envResolver *graphql_resolver.
 }
 
 func (helper *Helper) CreateProjectWithRepo(t *testing.T, envResolver *graphql_resolver.EnvironmentResolver, gitUrl string) *graphql_resolver.ProjectResolver {
-	envId := fmt.Sprintf("%v", envResolver.DBEnvironmentResolver.Environment.Model.ID)
 	projectInput := model.ProjectInput{
-		GitProtocol:   "HTTPS",
-		GitUrl:        gitUrl,
-		EnvironmentID: &envId,
+		GitProtocol: "HTTPS",
+		GitUrl:      gitUrl,
 	}
 
 	projectResolver, err := helper.Resolver.CreateProject(test.ResolverAuthContext(), &struct {

--- a/plugins/codeamp/graphql/mutation.go
+++ b/plugins/codeamp/graphql/mutation.go
@@ -107,7 +107,7 @@ func (r *Resolver) CreateProject(ctx context.Context, args *struct {
 	// Create git branch for env per env
 
 	environments := []model.Environment{}
-	if r.DB.Where("default = ?", true).Find(&environments).RecordNotFound() {
+	if r.DB.Find(&environments).RecordNotFound() {
 		log.InfoWithFields("No default envs found.", log.Fields{
 			"args": args,
 		})
@@ -120,6 +120,7 @@ func (r *Resolver) CreateProject(ctx context.Context, args *struct {
 			ProjectID:     project.Model.ID,
 			GitBranch:     "master",
 		})
+
 		// Create ProjectEnvironment rows for default envs
 		if environment.IsDefault {
 			r.DB.Create(&model.ProjectEnvironment{

--- a/plugins/codeamp/graphql/mutation.go
+++ b/plugins/codeamp/graphql/mutation.go
@@ -108,10 +108,10 @@ func (r *Resolver) CreateProject(ctx context.Context, args *struct {
 
 	environments := []model.Environment{}
 	if r.DB.Find(&environments).RecordNotFound() {
-		log.InfoWithFields("No default envs found.", log.Fields{
+		log.InfoWithFields("No envs found.", log.Fields{
 			"args": args,
 		})
-		return nil, fmt.Errorf("No default envs found")
+		return nil, fmt.Errorf("No envs found")
 	}
 
 	for _, environment := range environments {


### PR DESCRIPTION
## Description
This change removes EnvironmentID as a required param in `CreateProject`.

## Motivation and Context
1. We already know what Environments need to be provisioned for a project based on the default envs that have been enabled.

2. If a user is new to CodeAmp and has not been to a project page before, they will receive an error when trying to create a project since the EnvironmentID param on the client side is dependent on having currentEnvironment != null. This is not true if they have never been inside of a project before.

## How Has This Been Tested?
1. Tested locally
2. Modified CircleCI tests to reflect input changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
