### PR TITLE
fix: fix pagination logic to be consistent among all resolvers

### DIFF
--- a/plugins/codeamp/db/paginator.go
+++ b/plugins/codeamp/db/paginator.go
@@ -40,12 +40,12 @@ func (r *ReleaseListResolver) Entries() ([]*ReleaseResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at asc").Find(&rows)
+		r.Query.Order("created_at desc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -71,7 +71,7 @@ func (r *ReleaseListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit))), nil
 	} else {
 		return int32(1), nil
@@ -91,9 +91,9 @@ func (r *ReleaseListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -134,12 +134,12 @@ func (r *SecretListResolver) Entries() ([]*SecretResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at asc").Find(&rows)
+		r.Query.Order("created_at desc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -165,7 +165,7 @@ func (r *SecretListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
 	} else {
 		return int32(1), nil
@@ -185,9 +185,9 @@ func (r *SecretListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -228,12 +228,12 @@ func (r *ServiceListResolver) Entries() ([]*ServiceResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at asc").Find(&rows)
+		r.Query.Order("created_at desc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -259,7 +259,7 @@ func (r *ServiceListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit))), nil
 	} else {
 		return int32(1), nil
@@ -279,9 +279,9 @@ func (r *ServiceListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -322,12 +322,12 @@ func (r *FeatureListResolver) Entries() ([]*FeatureResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at asc").Find(&rows)
+		r.Query.Order("created_at desc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -353,7 +353,7 @@ func (r *FeatureListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
 	} else {
 		return int32(1), nil
@@ -373,9 +373,9 @@ func (r *FeatureListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -416,12 +416,12 @@ func (r *ProjectListResolver) Entries() ([]*ProjectResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at asc").Find(&rows)
+		r.Query.Order("created_at desc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -447,7 +447,7 @@ func (r *ProjectListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
 	} else {
 		return int32(1), nil
@@ -467,9 +467,9 @@ func (r *ProjectListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {

--- a/plugins/codeamp/db/paginator.go
+++ b/plugins/codeamp/db/paginator.go
@@ -40,12 +40,12 @@ func (r *ReleaseListResolver) Entries() ([]*ReleaseResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at desc").Find(&rows)
+		r.Query.Order("created_at asc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -71,8 +71,8 @@ func (r *ReleaseListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
+		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		return int32((index / int(*r.PaginatorInput.Limit))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -91,9 +91,9 @@ func (r *ReleaseListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -134,12 +134,12 @@ func (r *SecretListResolver) Entries() ([]*SecretResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at desc").Find(&rows)
+		r.Query.Order("created_at asc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -165,7 +165,7 @@ func (r *SecretListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit))), nil
 	} else {
 		return int32(1), nil
@@ -185,9 +185,9 @@ func (r *SecretListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -228,12 +228,12 @@ func (r *ServiceListResolver) Entries() ([]*ServiceResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at desc").Find(&rows)
+		r.Query.Order("created_at asc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -259,8 +259,8 @@ func (r *ServiceListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
+		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		return int32((index / int(*r.PaginatorInput.Limit))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -279,9 +279,9 @@ func (r *ServiceListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -322,12 +322,12 @@ func (r *FeatureListResolver) Entries() ([]*FeatureResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at desc").Find(&rows)
+		r.Query.Order("created_at asc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -353,7 +353,7 @@ func (r *FeatureListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
 	} else {
 		return int32(1), nil
@@ -373,9 +373,9 @@ func (r *FeatureListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {
@@ -416,12 +416,12 @@ func (r *ProjectListResolver) Entries() ([]*ProjectResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
-			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at asc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
 	} else {
-		r.Query.Order("created_at desc").Find(&rows)
+		r.Query.Order("created_at asc").Find(&rows)
 	}
 
 	for _, row := range rows {
@@ -447,7 +447,7 @@ func (r *ProjectListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		r.Query.Order("created_at asc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
 		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
 	} else {
 		return int32(1), nil
@@ -467,9 +467,9 @@ func (r *ProjectListResolver) NextCursor() (string, error) {
 
 	if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(nextCursorIdx).Find(&rows)
 	} else {
-		r.Query.Order("created_at desc").Limit(nextCursorIdx).Find(&rows)
+		r.Query.Order("created_at asc").Limit(nextCursorIdx).Find(&rows)
 	}
 
 	if len(rows) == nextCursorIdx {

--- a/plugins/codeamp/db/paginator.go
+++ b/plugins/codeamp/db/paginator.go
@@ -40,7 +40,7 @@ func (r *ReleaseListResolver) Entries() ([]*ReleaseResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
 			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
@@ -134,7 +134,7 @@ func (r *SecretListResolver) Entries() ([]*SecretResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
 			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
@@ -165,8 +165,8 @@ func (r *SecretListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
+		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		return int32((index / int(*r.PaginatorInput.Limit))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -228,7 +228,7 @@ func (r *ServiceListResolver) Entries() ([]*ServiceResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
 			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
@@ -322,7 +322,7 @@ func (r *FeatureListResolver) Entries() ([]*FeatureResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
 			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}
@@ -416,7 +416,7 @@ func (r *ProjectListResolver) Entries() ([]*ProjectResolver, error) {
 	if r.PaginatorInput != nil && r.PaginatorInput.Limit != nil {
 		if r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0 {
 			r.DB.Where("id = ?", *r.PaginatorInput.Cursor).First(&cursorRow)
-			r.Query.Order("created_at desc").Where("created_at < ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
+			r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		} else {
 			r.Query.Order("created_at desc").Limit(int(*r.PaginatorInput.Limit)).Find(&rows)
 		}

--- a/plugins/codeamp/db/paginator.go
+++ b/plugins/codeamp/db/paginator.go
@@ -166,7 +166,7 @@ func (r *SecretListResolver) Page() (int32, error) {
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
 		r.Query.Order("created_at asc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit))), nil
+		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
 	} else {
 		return int32(1), nil
 	}

--- a/plugins/codeamp/db/paginator.go
+++ b/plugins/codeamp/db/paginator.go
@@ -2,6 +2,7 @@ package db_resolver
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/codeamp/circuit/plugins/codeamp/model"
 	"github.com/jinzhu/gorm"
@@ -72,7 +73,7 @@ func (r *ReleaseListResolver) Page() (int32, error) {
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
 		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit))), nil
+		return int32(math.Ceil((float64(index) / float64(*r.PaginatorInput.Limit)))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -165,8 +166,8 @@ func (r *SecretListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
+		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		return int32(math.Ceil((float64(index) / float64(*r.PaginatorInput.Limit)))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -259,8 +260,8 @@ func (r *ServiceListResolver) Page() (int32, error) {
 
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
-		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit))), nil
+		r.Query.Order("created_at desc").Where("created_at >= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
+		return int32(math.Ceil((float64(index) / float64(*r.PaginatorInput.Limit)))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -354,7 +355,7 @@ func (r *FeatureListResolver) Page() (int32, error) {
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
 		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
+		return int32(math.Ceil((float64(index) / float64(*r.PaginatorInput.Limit)))), nil
 	} else {
 		return int32(1), nil
 	}
@@ -448,7 +449,7 @@ func (r *ProjectListResolver) Page() (int32, error) {
 	if (r.PaginatorInput.Cursor != nil && len(*r.PaginatorInput.Cursor) > 0) || r.PaginatorInput.Limit == nil {
 		r.DB.Where("id = ?", r.PaginatorInput.Cursor).Find(&cursorRow)
 		r.Query.Order("created_at desc").Where("created_at <= ?", cursorRow.Model.CreatedAt).Find(&rows).Count(&index)
-		return int32((index / int(*r.PaginatorInput.Limit)) + 1), nil
+		return int32(math.Ceil((float64(index) / float64(*r.PaginatorInput.Limit)))), nil
 	} else {
 		return int32(1), nil
 	}

--- a/plugins/codeamp/db/project.go
+++ b/plugins/codeamp/db/project.go
@@ -101,7 +101,7 @@ func (r *ProjectResolver) Secrets(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	query := r.DB.Select("key, id, created_at, type, project_id, environment_id, deleted_at, is_secret").Where("project_id = ? and environment_id = ?", r.Project.Model.ID, r.Environment.Model.ID).Order("key, created_at desc")
+	query := r.DB.Select("key, id, created_at, type, project_id, environment_id, deleted_at, is_secret").Where("project_id = ? and environment_id = ?", r.Project.Model.ID, r.Environment.Model.ID)
 	return &SecretListResolver{
 		DB:             r.DB,
 		Query:          query,

--- a/plugins/codeamp/db/project.go
+++ b/plugins/codeamp/db/project.go
@@ -101,7 +101,7 @@ func (r *ProjectResolver) Secrets(ctx context.Context, args *struct {
 		return nil, err
 	}
 
-	query := r.DB.Select("key, id, created_at, type, project_id, environment_id, deleted_at, is_secret").Where("project_id = ? and environment_id = ?", r.Project.Model.ID, r.Environment.Model.ID)
+	query := r.DB.Select("key, id, created_at, type, project_id, environment_id, deleted_at, is_secret").Where("project_id = ? and environment_id = ?", r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc")
 	return &SecretListResolver{
 		DB:             r.DB,
 		Query:          query,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. Add the correct conditional logic in Entries() querying for cursor rows (`<` --> `<=`) 
2. Modify division formula in Page()

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Page() and Entries() resolvers had incorrect querying logic which returned incorrect results. To be more specific:
1. Entries() did not return results including the nextCursor row object
2. Page() returned an off-by-one error as the division was not being `Math.ceil`'d

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally and on development environment in conjunction with Panel Pagination PR: https://github.com/codeamp/panel/pull/193. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

