### PR TITLE
Project Resolver: Return all associated releases

### DIFF
--- a/plugins/codeamp/db/project.go
+++ b/plugins/codeamp/db/project.go
@@ -71,7 +71,12 @@ func (r *ProjectResolver) CurrentRelease() (*ReleaseResolver, error) {
 func (r *ProjectResolver) Releases(args *struct {
 	Params *model.PaginatorInput
 }) *ReleaseListResolver {
-	query := r.DB.Where("project_id = ? and environment_id = ?", r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc")
+	var query *gorm.DB
+	if r.Environment != (model.Environment{}) {
+		query = r.DB.Where("project_id = ? and environment_id = ?", r.Project.Model.ID, r.Environment.Model.ID).Order("created_at desc")
+	} else {
+		query = r.DB.Where("project_id = ?", r.Project.Model.ID).Order("created_at desc")
+	}
 
 	return &ReleaseListResolver{
 		PaginatorInput: args.Params,


### PR DESCRIPTION
This change is required for the dashboard to be able to query all projects' releases without having to do additional queries. If there is no environment associated, just return all releases for a project.