### PR TITLE
Fixes Secret's Versions Timestamps

### DIFF
--- a/plugins/codeamp/graphql/secret.go
+++ b/plugins/codeamp/graphql/secret.go
@@ -86,7 +86,10 @@ func (r *SecretResolver) Environment() *EnvironmentResolver {
 
 // Created
 func (r *SecretResolver) Created() graphql.Time {
-	return graphql.Time{Time: r.DBSecretResolver.Secret.Model.CreatedAt}
+	if r.DBSecretResolver.SecretValue == (model.SecretValue{}) {
+		return graphql.Time{Time: r.DBSecretResolver.Secret.Model.CreatedAt}
+	}
+	return graphql.Time{Time: r.DBSecretResolver.SecretValue.Model.CreatedAt}
 }
 
 // IsSecret


### PR DESCRIPTION
**Describe the bug**
v2+ updated secret "Created At" value is incorrect, seems to just use the date from v1.

**To Reproduce**
Steps to reproduce the behavior:

Go to Secrets section of a Project
Save at least two versions of one secret
Expected behavior
The "Completed At" column for v2 should be the actual creation datetime

Fixes https://github.com/codeamp/panel/issues/207