### PR TITLE
Remove slack token from slack test

### DIFF
--- a/plugins/gitsync/gitsync.go
+++ b/plugins/gitsync/gitsync.go
@@ -60,7 +60,7 @@ func (x *GitSync) Start(e chan transistor.Event) error {
 }
 
 func (x *GitSync) Stop() {
-	log.Println("Stopping GitSync")
+	log.Info("Stopping GitSync")
 }
 
 func (x *GitSync) Subscribe() []string {
@@ -152,7 +152,7 @@ func (x *GitSync) commits(project plugins.Project, git plugins.Git) ([]plugins.G
 			return nil, err
 		}
 
-		log.Info(string(output))
+		log.Debug(string(output))
 	}
 
 	output, err = x.git(env, "-C", repoPath, "reset", "--hard", fmt.Sprintf("origin/%s", git.Branch))
@@ -161,7 +161,7 @@ func (x *GitSync) commits(project plugins.Project, git plugins.Git) ([]plugins.G
 		return nil, err
 	}
 
-	log.Info(string(output))
+	log.Debug(string(output))
 
 	output, err = x.git(env, "-C", repoPath, "clean", "-fd")
 	if err != nil {
@@ -169,7 +169,7 @@ func (x *GitSync) commits(project plugins.Project, git plugins.Git) ([]plugins.G
 		return nil, err
 	}
 
-	log.Info(string(output))
+	log.Debug(string(output))
 
 	output, err = x.git(env, "-C", repoPath, "pull", "origin", git.Branch)
 	if err != nil {
@@ -177,7 +177,7 @@ func (x *GitSync) commits(project plugins.Project, git plugins.Git) ([]plugins.G
 		return nil, err
 	}
 
-	log.Info(string(output))
+	log.Debug(string(output))
 
 	output, err = x.git(env, "-C", repoPath, "checkout", git.Branch)
 	if err != nil {
@@ -185,7 +185,7 @@ func (x *GitSync) commits(project plugins.Project, git plugins.Git) ([]plugins.G
 		return nil, err
 	}
 
-	log.Info(string(output))
+	log.Debug(string(output))
 
 	output, err = x.git(env, "-C", repoPath, "log", "--first-parent", "--date=iso-strict", "-n", "50", "--pretty=format:%H#@#%P#@#%s#@#%cN#@#%cd", git.Branch)
 

--- a/plugins/slack/slack_test.go
+++ b/plugins/slack/slack_test.go
@@ -93,7 +93,6 @@ func (suite *TestSuite) TestSlack() {
 	var err error
 
 	ev = transistor.NewEvent(plugins.GetEventName("slack"), transistor.GetAction("create"), getTestProjectExtensionPayload())
-	// ev.AddArtifact("webhook_url", "https://hooks.slack.com/services/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", false)
 	ev.AddArtifact("webhook_url", "http://hooks.slack.com/services/token/token/valid_token", false)
 	ev.AddArtifact("channel", "devops-test", false)
 


### PR DESCRIPTION
* Remove slack token from slack test. 
* Silence gitsync info logs to debug channel