### PR TITLE
Log warning instead of failing when calling StopRelease on misconfigured release objects.

### DIFF
--- a/plugins/codeamp/graphql/mutation.go
+++ b/plugins/codeamp/graphql/mutation.go
@@ -224,7 +224,9 @@ func (r *Resolver) StopRelease(ctx context.Context, args *struct{ ID graphql.ID 
 
 	r.DB.Where("release_id = ?", args.ID).Find(&releaseExtensions)
 	if len(releaseExtensions) < 1 {
-		return nil, fmt.Errorf("No release extensions found for release: %s", args.ID)
+		log.WarnWithFields("No release extensions found for release: %s", log.Fields{
+			"id": args.ID,
+		})
 	}
 
 	if r.DB.Where("id = ?", args.ID).Find(&release).RecordNotFound() {

--- a/plugins/codeamp/graphql/release_test.go
+++ b/plugins/codeamp/graphql/release_test.go
@@ -1009,8 +1009,39 @@ func (ts *ReleaseTestSuite) TestStopReleaseFailureBadReleaseExtension() {
 }
 
 func (ts *ReleaseTestSuite) TestStopReleaseFailureNoReleaseExtensions() {
-	_, err := ts.Resolver.StopRelease(test.ResolverAuthContext(), &struct{ ID graphql.ID }{graphql.ID("b3d43558-0ec0-44a5-9755-0a3a0387d8eb")})
-	assert.NotNil(ts.T(), err)
+	// Environment
+	environmentResolver := ts.helper.CreateEnvironment(ts.T())
+
+	// Project
+	projectResolver, err := ts.helper.CreateProject(ts.T(), environmentResolver)
+	if err != nil {
+		assert.FailNow(ts.T(), err.Error())
+	}
+
+	// Secret
+	_ = ts.helper.CreateSecret(ts.T(), projectResolver)
+
+	// Extension
+	extensionResolver := ts.helper.CreateExtension(ts.T(), environmentResolver)
+
+	// Project Extension
+	projectExtensionResolver := ts.helper.CreateProjectExtension(ts.T(), extensionResolver, projectResolver)
+
+	// Force to set to 'complete' state for testing purposes
+	projectExtensionResolver.DBProjectExtensionResolver.ProjectExtension.State = "complete"
+	projectExtensionResolver.DBProjectExtensionResolver.ProjectExtension.StateMessage = "Forced Completion via Test"
+	ts.Resolver.DB.Save(&projectExtensionResolver.DBProjectExtensionResolver.ProjectExtension)
+
+	// Feature
+	featureResolver := ts.helper.CreateFeature(ts.T(), projectResolver)
+
+	// Release
+	releaseResolver := ts.helper.CreateRelease(ts.T(), featureResolver, projectResolver)
+
+	_, err = ts.Resolver.StopRelease(test.ResolverAuthContext(), &struct{ ID graphql.ID }{releaseResolver.ID()})
+	if err != nil {
+		assert.FailNow(ts.T(), err.Error())
+	}
 }
 
 func (ts *ReleaseTestSuite) TestCreateRollbackReleaseSuccess() {


### PR DESCRIPTION
fixes #339 