### PR TITLE
Fixes Extension Query Improper Where Clause

### DIFF
--- a/plugins/codeamp/graphql/extension_query.go
+++ b/plugins/codeamp/graphql/extension_query.go
@@ -29,7 +29,7 @@ func (r *ExtensionResolverQuery) Extensions(ctx context.Context, args *struct{ E
 
 	db.Order("environment_id asc, name asc").Find(&rows)
 	for _, ext := range rows {
-		results = append(results, &ExtensionResolver{DBExtensionResolver: &db_resolver.ExtensionResolver{DB: db, Extension: ext}})
+		results = append(results, &ExtensionResolver{DBExtensionResolver: &db_resolver.ExtensionResolver{DB: r.DB, Extension: ext}})
 	}
 
 	return results, nil


### PR DESCRIPTION
This odd error popped up about missing a FROM clause for a table. This is because a gorm DB instance was reused after a Where had been applied to it. This carried on into another query and polluted the results of this query. The extensions_query.go is the source of this issue and carried on into extension resolver's Environment() query.

The fix is to provide the extension resolver with the correct DB that does not have a Where clause applied to it.

```
circuit_1   | [00] (/go/src/github.com/codeamp/circuit/plugins/codeamp/db/extension.go:19)
circuit_1   | [00] [2018-11-16 18:36:58]  pq: missing FROM-clause entry for table "extensions"
circuit_1   | [00]
circuit_1   | [00] (/go/src/github.com/codeamp/circuit/plugins/codeamp/db/extension.go:19)
circuit_1   | [00] [2018-11-16 18:36:58]  [444.93ms]  SELECT * FROM "environments"  WHERE "environments"."deleted_at" IS NULL AND ((extensions.environment_id = '179dc8ca-fbea-4e68-9cad-d45e54cfa7a7') AND (id = '179dc8ca-fbea-4e68-9cad-d45e54cfa7a7')) ORDER BY "environments"."id" ASC LIMIT 1
circuit_1   | [00] [0 rows affected or returned ]
```