### PR TITLE
Pin Golang Base Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/coreos/dex:v2.10.0
-FROM golang:1.10-alpine
+FROM golang:1.10.4-alpine
 
 COPY --from=0 /usr/local/bin/dex /usr/local/bin/dex
 
@@ -17,3 +17,4 @@ RUN go get -v -u github.com/jteeuwen/go-bindata/...
 RUN mkdir -p assets/
 RUN /go/bin/go-bindata -pkg assets -o assets/assets.go plugins/codeamp/graphql/schema.graphql
 RUN go build -i -v -o /go/bin/codeamp-circuit .
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,7 @@ WORKDIR $APP_PATH
 COPY . $APP_PATH
 
 RUN go get -u github.com/cespare/reflex
-RUN go version
-RUN go get -v -u github.com/jteeuwen/go-bindata/...
+RUN go get -u github.com/jteeuwen/go-bindata/...
 RUN mkdir -p assets/
 RUN /go/bin/go-bindata -pkg assets -o assets/assets.go plugins/codeamp/graphql/schema.graphql
 RUN go build -i -v -o /go/bin/codeamp-circuit .
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM quay.io/coreos/dex:v2.10.0
-FROM golang:alpine
+FROM golang:1.10-alpine
 
 COPY --from=0 /usr/local/bin/dex /usr/local/bin/dex
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR $APP_PATH
 COPY . $APP_PATH
 
 RUN go get -u github.com/cespare/reflex
+RUN go version
 RUN go get -v -u github.com/jteeuwen/go-bindata/...
 RUN mkdir -p assets/
 RUN /go/bin/go-bindata -pkg assets -o assets/assets.go plugins/codeamp/graphql/schema.graphql

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR $APP_PATH
 COPY . $APP_PATH
 
 RUN go get -u github.com/cespare/reflex
-RUN go get -u github.com/jteeuwen/go-bindata/...
+RUN go get -v -u github.com/jteeuwen/go-bindata/...
 RUN mkdir -p assets/
 RUN /go/bin/go-bindata -pkg assets -o assets/assets.go plugins/codeamp/graphql/schema.graphql
 RUN go build -i -v -o /go/bin/codeamp-circuit .


### PR DESCRIPTION
The "alpine" tag is basically the same as using "latest" which does not always point at the same version.
The latest/alpine tag was updated and there is at least one breaking change. Pin to a version specific tag until we determine impact.