### PR TITLE
DockerBuilder Fetches

### DIFF
--- a/plugins/dockerbuilder/dockerbuilder.go
+++ b/plugins/dockerbuilder/dockerbuilder.go
@@ -144,6 +144,12 @@ func (x *DockerBuilder) bootstrap(repoPath string, event transistor.Event) error
 		log.Info(string(output))
 	}
 
+	output, err = x.git(env, "-C", repoPath, "fetch")
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+
 	output, err = x.git(env, "-C", repoPath, "reset", "--hard", fmt.Sprintf("origin/%s", payload.Release.Git.Branch))
 	if err != nil {
 		log.Error(err)


### PR DESCRIPTION
* Before performing git sync in DockerBuilder, make sure we fetch and then do `reset --hard`