### PR TITLE
Add logging for Project/Settings changes

### DIFF
--- a/plugins/codeamp/auth/auth.go
+++ b/plugins/codeamp/auth/auth.go
@@ -16,7 +16,7 @@ func getJWTToken(ctx context.Context) (*model.Claims, error) {
 	}
 	claims := ctx.Value("jwt").(model.Claims)
 	if claims.UserID == "" {
-		return nil, errors.New(claims.TokenError)
+		return nil, errors.New(fmt.Sprintf("%s %v", "Missing UserID", claims.TokenError))
 	}
 
 	return &claims, nil

--- a/plugins/codeamp/graphql/mutation.go
+++ b/plugins/codeamp/graphql/mutation.go
@@ -22,11 +22,11 @@ func (r *Resolver) CreateProject(ctx context.Context, args *struct {
 }
 
 // UpdateProject Update project
-func (r *Resolver) UpdateProject(args *struct {
+func (r *Resolver) UpdateProject(ctx context.Context, args *struct {
 	Project *model.ProjectInput
 }) (*ProjectResolver, error) {
 	mut := ProjectResolverMutation{r.DB}
-	return mut.UpdateProject(args)
+	return mut.UpdateProject(ctx, args)
 }
 
 // StopRelease

--- a/plugins/codeamp/graphql/project_mutation.go
+++ b/plugins/codeamp/graphql/project_mutation.go
@@ -187,6 +187,7 @@ func (r *ProjectResolverMutation) UpdateProject(ctx context.Context, args *struc
 			return nil, fmt.Errorf("Couldn't parse environment ID")
 		}
 
+		oldBranchName := ""
 		var projectSettings model.ProjectSettings
 		if r.DB.Where("environment_id = ? and project_id = ?", environmentID, projectID).First(&projectSettings).RecordNotFound() {
 			projectSettings.EnvironmentID = environmentID
@@ -194,6 +195,7 @@ func (r *ProjectResolverMutation) UpdateProject(ctx context.Context, args *struc
 			projectSettings.GitBranch = *args.Project.GitBranch
 			projectSettings.ContinuousDeploy = *args.Project.ContinuousDeploy
 		} else {
+			oldBranchName = projectSettings.GitBranch
 			projectSettings.GitBranch = *args.Project.GitBranch
 			projectSettings.ContinuousDeploy = *args.Project.ContinuousDeploy
 		}
@@ -211,6 +213,7 @@ func (r *ProjectResolverMutation) UpdateProject(ctx context.Context, args *struc
 		log.WarnWithFields("[AUDIT] Updated Project Branch", log.Fields{
 			"project":     project.Slug,
 			"branch":      *args.Project.GitBranch,
+			"oldBranch":   oldBranchName,
 			"user":        userID,
 			"environment": environmentID},
 		)

--- a/plugins/codeamp/graphql/project_mutation.go
+++ b/plugins/codeamp/graphql/project_mutation.go
@@ -143,7 +143,7 @@ func (r *ProjectResolverMutation) CreateProject(ctx context.Context, args *struc
 }
 
 // UpdateProject Update project
-func (r *ProjectResolverMutation) UpdateProject(args *struct {
+func (r *ProjectResolverMutation) UpdateProject(ctx context.Context, args *struct {
 	Project *model.ProjectInput
 }) (*ProjectResolver, error) {
 	var project model.Project
@@ -193,17 +193,39 @@ func (r *ProjectResolverMutation) UpdateProject(args *struct {
 			projectSettings.ProjectID = projectID
 			projectSettings.GitBranch = *args.Project.GitBranch
 			projectSettings.ContinuousDeploy = *args.Project.ContinuousDeploy
-
-			r.DB.Save(&projectSettings)
 		} else {
 			projectSettings.GitBranch = *args.Project.GitBranch
 			projectSettings.ContinuousDeploy = *args.Project.ContinuousDeploy
+		}
 
-			r.DB.Save(&projectSettings)
+		_userID, err := auth.CheckAuth(ctx, []string{})
+		if err != nil {
+			return nil, err
+		}
+
+		userID, err := uuid.FromString(_userID)
+		if err != nil {
+			return nil, err
+		}
+
+		log.WarnWithFields("[AUDIT] Updated Project Branch", log.Fields{
+			"project":     project.Slug,
+			"branch":      *args.Project.GitBranch,
+			"user":        userID,
+			"environment": environmentID},
+		)
+
+		// Save after all error conditions have passed
+		if err = r.DB.Save(&projectSettings).Error; err != nil {
+			log.Error(err)
+			return nil, err
 		}
 	}
 
-	r.DB.Save(&project)
+	if err := r.DB.Save(&project).Error; err != nil {
+		log.Error(err)
+		return nil, err
+	}
 
 	return &ProjectResolver{DBProjectResolver: &db_resolver.ProjectResolver{DB: r.DB, Project: project}}, nil
 }

--- a/plugins/codeamp/graphql/project_test.go
+++ b/plugins/codeamp/graphql/project_test.go
@@ -522,7 +522,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectHTTPSSuccess() {
 		EnvironmentID: &envID,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updatedProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updatedProjectInput})
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), updatedProjectResolver)
 
@@ -555,7 +556,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectHTTPSMismatchSuccess() {
 		EnvironmentID: &envID,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updatedProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updatedProjectInput})
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), updatedProjectResolver)
 
@@ -592,7 +594,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHSuccess() {
 		ContinuousDeploy: &continuousDeploy,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updatedProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updatedProjectInput})
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), updatedProjectResolver)
 
@@ -601,6 +604,7 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHSuccess() {
 }
 
 func (suite *ProjectTestSuite) TestUpdateProjectSSHMismatchSuccess() {
+	var err error
 	// Environment
 	environmentResolver := suite.helper.CreateEnvironment(suite.T())
 
@@ -629,9 +633,14 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHMismatchSuccess() {
 		ContinuousDeploy: &continuousDeploy,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updatedProjectInput})
-	assert.Nil(suite.T(), err)
-	assert.NotNil(suite.T(), updatedProjectResolver)
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updatedProjectInput})
+	if err != nil {
+		assert.FailNow(suite.T(), err.Error())
+	}
+	if updatedProjectResolver == nil {
+		assert.FailNow(suite.T(), "Project Resolver is nil")
+	}
 
 	assert.Equal(suite.T(), updatedProjectInput.GitProtocol, updatedProjectResolver.GitProtocol())
 	assert.Equal(suite.T(), "https://github.com/foo/goo.git", updatedProjectResolver.GitUrl())
@@ -678,7 +687,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHSuccessNoEnvironment() {
 		assert.FailNow(suite.T(), err.Error())
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updatedProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updatedProjectInput})
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), updatedProjectResolver)
 
@@ -695,7 +705,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectFailureNoID() {
 
 	updateProjectInput := model.ProjectInput{}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updateProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updateProjectInput})
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), updatedProjectResolver)
 }
@@ -717,7 +728,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectFailureWrongProjectID() {
 		ContinuousDeploy: &continuousDeploy,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updateProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updateProjectInput})
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), updatedProjectResolver)
 }
@@ -739,7 +751,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectFailureInvalidProjectID() {
 		ContinuousDeploy: &continuousDeploy,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updateProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updateProjectInput})
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), updatedProjectResolver)
 }
@@ -769,7 +782,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectFailureInvalidEnvironmentID() {
 		ContinuousDeploy: &continuousDeploy,
 	}
 
-	updatedProjectResolver, err := suite.Resolver.UpdateProject(&struct{ Project *model.ProjectInput }{&updateProjectInput})
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
+	updatedProjectResolver, err := suite.Resolver.UpdateProject(ctx, &struct{ Project *model.ProjectInput }{&updateProjectInput})
 	assert.NotNil(suite.T(), err)
 	assert.Nil(suite.T(), updatedProjectResolver)
 }
@@ -895,7 +909,7 @@ func (suite *ProjectTestSuite) TestBookmarkProjectFailureNoAuth() {
 func (suite *ProjectTestSuite) TestBookmarkProjectFailureBadProjectID() {
 	projectID := test.InvalidUUID
 
-	var ctx context.Context
+	ctx := test.BuildAuthContext("ba16258e-2b27-43c4-82c1-228279049529", "test@example.com", []string{})
 	_, err := suite.Resolver.BookmarkProject(ctx, &struct{ ID graphql.ID }{graphql.ID(projectID)})
 	assert.NotNil(suite.T(), err)
 }

--- a/test/test.go
+++ b/test/test.go
@@ -63,7 +63,7 @@ func SetupResolverTest(migrators []interface{}) (*gorm.DB, error) {
 // Generates a fake JWT token for testing purposes
 // Use for testing graphql resolvers
 func ResolverAuthContext() context.Context {
-	return BuildAuthContext("11075553-5309-494B-9085-2D79A6ED1EB3", "foo@gmail.com", []string{"admin"})
+	return BuildAuthContext("11075553-5309-494B-9085-2D79A6ED1EB3", "foo@example.com", []string{"admin"})
 }
 
 // Generates a fake JWT token for testing purposes


### PR DESCRIPTION
* Added AUDIT logging for changing the settings branch
* Includes the following: environmentID, userID, project name, and new/old branch name.
* Updated auth to provide proper error in case of context with no UserID (was previously blank)
* Updated several test cases in `project_test.go` to support mutation/queries with context arguments