### PR TITLE
Add 'must be general type' condition if creating ports in createService

### DIFF
--- a/plugins/codeamp/graphql/service_mutation.go
+++ b/plugins/codeamp/graphql/service_mutation.go
@@ -450,7 +450,7 @@ func (r *ServiceResolverMutation) createServiceInDB(tx *gorm.DB, serviceInput *m
 		}
 	}
 
-	if serviceInput.Ports != nil {
+	if serviceInput.Ports != nil && serviceInput.Type == string(plugins.GetType("general")) {
 		for _, cp := range *serviceInput.Ports {
 			servicePort := model.ServicePort{
 				ServiceID: service.ID,

--- a/plugins/codeamp/graphql/service_mutation.go
+++ b/plugins/codeamp/graphql/service_mutation.go
@@ -450,14 +450,18 @@ func (r *ServiceResolverMutation) createServiceInDB(tx *gorm.DB, serviceInput *m
 		}
 	}
 
-	if serviceInput.Ports != nil && serviceInput.Type == string(plugins.GetType("general")) {
-		for _, cp := range *serviceInput.Ports {
-			servicePort := model.ServicePort{
-				ServiceID: service.ID,
-				Port:      cp.Port,
-				Protocol:  cp.Protocol,
+	if serviceInput.Ports != nil {
+		if serviceInput.Type == string(plugins.GetType("general")) {
+			for _, cp := range *serviceInput.Ports {
+				servicePort := model.ServicePort{
+					ServiceID: service.ID,
+					Port:      cp.Port,
+					Protocol:  cp.Protocol,
+				}
+				tx.Create(&servicePort)
 			}
-			tx.Create(&servicePort)
+		} else {
+			return nil, fmt.Errorf("Can only create ports if the service type is general")
 		}
 	}
 

--- a/plugins/codeamp/graphql/service_test.go
+++ b/plugins/codeamp/graphql/service_test.go
@@ -756,6 +756,34 @@ func (ts *ServiceTestSuite) TestUpdateServiceSuccess() {
 		assert.FailNow(ts.T(), err.Error())
 	}
 }
+func (ts *ServiceTestSuite) TestCreateService_Fail_OneShotWithPorts() {
+	// Environment
+	envResolver := ts.helper.CreateEnvironment(ts.T())
+
+	// Project
+	projectResolver, err := ts.helper.CreateProject(ts.T(), envResolver)
+	if err != nil {
+		assert.FailNow(ts.T(), err.Error())
+	}
+
+	// Service Spec ID
+	ts.helper.CreateServiceSpec(ts.T(), true)
+
+	// Create Service
+	servicePorts := []model.ServicePortInput{
+		{
+			Port:     80,
+			Protocol: "HTTP",
+		},
+	}
+	serviceInput := &model.ServiceInput{
+		Type:      "one-shot",
+		ProjectID: string(projectResolver.ID()),
+		Ports:     &servicePorts,
+	}
+	_, err = ts.Resolver.CreateService(&struct{ Service *model.ServiceInput }{serviceInput})
+	assert.NotNil(ts.T(), err)
+}
 
 func (ts *ServiceTestSuite) TestUpdateServiceFailureNullID() {
 	// Environment

--- a/plugins/codeamp/graphql/service_test.go
+++ b/plugins/codeamp/graphql/service_test.go
@@ -777,9 +777,10 @@ func (ts *ServiceTestSuite) TestCreateService_Fail_OneShotWithPorts() {
 		},
 	}
 	serviceInput := &model.ServiceInput{
-		Type:      "one-shot",
-		ProjectID: string(projectResolver.ID()),
-		Ports:     &servicePorts,
+		Type:          "one-shot",
+		ProjectID:     string(projectResolver.ID()),
+		Ports:         &servicePorts,
+		EnvironmentID: string(envResolver.ID()),
 	}
 	_, err = ts.Resolver.CreateService(&struct{ Service *model.ServiceInput }{serviceInput})
 	assert.NotNil(ts.T(), err)


### PR DESCRIPTION
We should only create ports if it makes sense to do so i.e. when the Service type can make use of the exposed ports. In this case, only `general` services allow port creation. This enforces that condition in the mutation