### PR TITLE
Add "project" scope when importing secrets

### DIFF
--- a/plugins/codeamp/graphql/secret_mutation.go
+++ b/plugins/codeamp/graphql/secret_mutation.go
@@ -184,6 +184,7 @@ func (r *SecretResolverMutation) ImportSecrets(ctx context.Context, args *struct
 			ProjectID:     project.Model.ID,
 			EnvironmentID: env.Model.ID,
 			IsSecret:      importedSecret.IsSecret,
+			Scope:         "project",
 		}
 		newSecretValue := model.SecretValue{
 			Value:  importedSecret.Value,

--- a/plugins/codeamp/graphql/secret_test.go
+++ b/plugins/codeamp/graphql/secret_test.go
@@ -535,7 +535,6 @@ func (ts *SecretTestSuite) TestSecretsImport_Success_ProtectedSecretCreated() {
 	}
 
 	assert.Equal(ts.T(), 2, len(secretsResolver))
-
 	// check that protected was created
 	page := int32(0)
 	limit := int32(1)
@@ -574,6 +573,8 @@ func (ts *SecretTestSuite) TestSecretsImport_Success_ProtectedSecretCreated() {
 			protectedCount += 1
 			assert.Equal(ts.T(), "******", secret.Value())
 		}
+
+		assert.Equal(ts.T(), "project", secret.Scope())
 	}
 
 	assert.Equal(ts.T(), 1, protectedCount)


### PR DESCRIPTION
In ImportSecrets, the scope is not explicitly defined, so the scope is a blank string. This leads the Secrets() query to pull it since it is looking for secrets that don't have "project" defined as the scope, including blank strings. This means we show these secrets on the Admin/Secrets page which is undesired.

Fix: add "project" scope when creating a secret.