### PR TITLE
Ignore ports variable if length is 0

### DIFF
--- a/plugins/codeamp/graphql/service_mutation.go
+++ b/plugins/codeamp/graphql/service_mutation.go
@@ -450,7 +450,7 @@ func (r *ServiceResolverMutation) createServiceInDB(tx *gorm.DB, serviceInput *m
 		}
 	}
 
-	if serviceInput.Ports != nil {
+	if serviceInput.Ports != nil && len(*serviceInput.Ports) > 0 {
 		if serviceInput.Type == string(plugins.GetType("general")) {
 			for _, cp := range *serviceInput.Ports {
 				servicePort := model.ServicePort{

--- a/plugins/codeamp/graphql/service_test.go
+++ b/plugins/codeamp/graphql/service_test.go
@@ -180,6 +180,7 @@ func (suite *ServiceTestSuite) SetupTest() {
 		&model.ProjectBookmark{},
 		&model.UserPermission{},
 		&model.ServiceSpec{},
+		&model.ServicePort{},
 	}
 
 	db, err := test.SetupResolverTest(migrators)
@@ -813,7 +814,10 @@ func (ts *ServiceTestSuite) TestCreateService_Success_OneShot() {
 	serviceResolver, err := ts.Resolver.CreateService(&struct{ Service *model.ServiceInput }{serviceInput})
 	assert.Nil(ts.T(), err)
 
+	ports, _ := serviceResolver.Ports()
+
 	assert.Equal(ts.T(), serviceResolver.Type(), serviceInput.Type)
+	assert.Equal(ts.T(), len(ports), 0)
 }
 
 func (ts *ServiceTestSuite) TestUpdateServiceFailureNullID() {

--- a/plugins/codeamp/graphql/service_test.go
+++ b/plugins/codeamp/graphql/service_test.go
@@ -177,6 +177,9 @@ func (suite *ServiceTestSuite) SetupTest() {
 		&model.Project{},
 		&model.ProjectEnvironment{},
 		&model.Extension{},
+		&model.ProjectBookmark{},
+		&model.UserPermission{},
+		&model.ServiceSpec{},
 	}
 
 	db, err := test.SetupResolverTest(migrators)
@@ -784,6 +787,33 @@ func (ts *ServiceTestSuite) TestCreateService_Fail_OneShotWithPorts() {
 	}
 	_, err = ts.Resolver.CreateService(&struct{ Service *model.ServiceInput }{serviceInput})
 	assert.NotNil(ts.T(), err)
+}
+
+func (ts *ServiceTestSuite) TestCreateService_Success_OneShot() {
+	// Environment
+	envResolver := ts.helper.CreateEnvironment(ts.T())
+
+	// Project
+	projectResolver, err := ts.helper.CreateProject(ts.T(), envResolver)
+	if err != nil {
+		assert.FailNow(ts.T(), err.Error())
+	}
+
+	// Service Spec ID
+	ts.helper.CreateServiceSpec(ts.T(), true)
+
+	// Create Service
+	servicePorts := []model.ServicePortInput{}
+	serviceInput := &model.ServiceInput{
+		Type:          "one-shot",
+		ProjectID:     string(projectResolver.ID()),
+		Ports:         &servicePorts,
+		EnvironmentID: string(envResolver.ID()),
+	}
+	serviceResolver, err := ts.Resolver.CreateService(&struct{ Service *model.ServiceInput }{serviceInput})
+	assert.Nil(ts.T(), err)
+
+	assert.Equal(ts.T(), serviceResolver.Type(), serviceInput.Type)
 }
 
 func (ts *ServiceTestSuite) TestUpdateServiceFailureNullID() {


### PR DESCRIPTION
Only go through the ports-creation logic in the service mutation if the length of the ports input is greater than 0. Currently, we pass in a ports variable from the client-side regardless of the service type. However, the one-shot service type passes in a 0 length, non-nil ports parameter which means we cannot create one-shot services from the panel client inputs right now.

This fixes it by allowing to hit ports creation logic only if it is not nil **and** the ports length is greater than 0.