### PR TITLE
Add ResourceConfig interface

### DIFF
--- a/plugins/codeamp/resourceconfig/errors.go
+++ b/plugins/codeamp/resourceconfig/errors.go
@@ -1,0 +1,7 @@
+package resourceconfig
+
+const (
+	NilDependencyForExportErr = "required dependency for exporting missing %s"
+	FailedTypeAssertionErr    = "failed to assert type %s"
+	ObjectAlreadyExistsErr    = "%s object already exists"
+)

--- a/plugins/codeamp/resourceconfig/resourceconfig.go
+++ b/plugins/codeamp/resourceconfig/resourceconfig.go
@@ -1,0 +1,29 @@
+package resourceconfig
+
+// A ResourceConfig is an object that is used for importing and exporting
+// resources in CodeAmp. Its purpose is to decouple implementation behaviors
+// of Export and Import from objects when the respective operation is occurring
+// and provide a general-purpose interface for any resource that wants to implement
+// import/export behaviors.
+type ResourceConfig interface {
+	Import(interface{}) error
+	Export(interface{}) (interface{}, error)
+}
+
+// BaseResourceConfig is used for
+// incorporating into any struct that wants
+// to implement ResourceConfig
+type BaseResourceConfig struct{}
+
+// Import takes in an input in its exported format
+// and persists it into the system's database
+func (b *BaseResourceConfig) Import(obj interface{}) error {
+	return nil
+}
+
+// Export takes in an input that can be transformed into
+// its corresponding export format e.g. transforming a model.Service
+// into a resourceconfig.Service
+func (b *BaseResourceConfig) Export(obj interface{}) (interface{}, error) {
+	return obj, nil
+}


### PR DESCRIPTION
Addresses part of https://github.com/codeamp/circuit/issues/436

The `ResourceConfig` is the interface that will be used for all objects we choose to be importable/ exportable. We create the `ResourceConfig` for two reasons:

1. For each object's implementation, we want to have an explicit input standard when something must be imported. For instance, if we are importing a YAML string in our resolver logic, we transform that into the proper input format before passing it in to the Import function. 

2. We want to control what information should be exportable to the end-user and how it is shown. For instance, if we are exporting a project extension, we want to put its `Extension` key on the same level as the project extension properties and omit any `Extension` config information since the end-user should never know about that.