### PR TITLE
Add database plugin with initial Postgres support

### DIFF
--- a/plugins/database/constants.go
+++ b/plugins/database/constants.go
@@ -1,5 +1,6 @@
 package database
 
 const (
-	POSTGRESQL = "postgresql"
+	POSTGRESQL         = "postgresql"
+	DB_PASSWORD_LENGTH = 32
 )

--- a/plugins/database/constants.go
+++ b/plugins/database/constants.go
@@ -1,0 +1,5 @@
+package database
+
+const (
+	POSTGRESQL = "postgresql"
+)

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -45,15 +45,16 @@ func (x *Database) Stop() {
 // Subscribe
 func (x *Database) Subscribe() []string {
 	return []string{
-		"project:database",
+		"project:database:create",
+		"project:database:delete",
 	}
 }
 
-func getFailedStatusEvent(err error) transistor.Event {
+func (x *Database) sendFailedStatusEvent(err error) {
 	ev := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), nil)
 	ev.State = transistor.GetState("failed")
 	ev.StateMessage = err.Error()
-	return ev
+	x.events <- ev
 }
 
 // Process
@@ -62,80 +63,96 @@ func (x *Database) Process(e transistor.Event) error {
 
 	// confirm all required structured inputs (Project slug, Environment)
 	if e.PayloadModel != "plugins.ProjectExtension" {
-		err := errors.New("invalid payload model")
-		log.Error(err.Error())
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(errors.New("invalid payload model"))
+		return nil
 	}
 
 	projectExtensionEvent := e.Payload.(plugins.ProjectExtension)
 
-	// Create DB within shared instance of the correct db variant (postgres/mysql)
 	instanceEndpoint, err := e.GetArtifact("SHARED_DATABASE_HOST")
 	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(err)
+		return nil
 	}
 
 	instanceUsername, err := e.GetArtifact("SHARED_DATABASE_ADMIN_USERNAME")
 	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(err)
+		return nil
 	}
 
 	instancePassword, err := e.GetArtifact("SHARED_DATABASE_ADMIN_PASSWORD")
 	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(err)
+		return nil
 	}
 
 	instancePort, err := e.GetArtifact("SHARED_DATABASE_PORT")
 	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(err)
+		return nil
 	}
 
 	dbType, err := e.GetArtifact("DB_TYPE")
 	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(err)
+		return nil
 	}
 
 	dbInstance, err := initDBInstance(dbType.String(), instanceEndpoint.String(), instanceUsername.String(), instancePassword.String(), instancePort.String())
 	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+		x.sendFailedStatusEvent(err)
+		return nil
 	}
 
-	dbUsername, err := genDBUser(projectExtensionEvent)
-	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
+	// Create DB within shared instance of the correct db variant (postgres/mysql)
+	switch e.Action {
+	case transistor.GetAction("create"):
+		dbUsername := genDBUser(projectExtensionEvent)
+		dbName := genDBName(projectExtensionEvent)
+		dbPassword := genDBPassword()
+
+		dbMetadata, err := (*dbInstance).CreateDatabaseAndUser(dbName, dbUsername, dbPassword)
+		if err != nil {
+			x.sendFailedStatusEvent(err)
+			return nil
+		}
+
+		// store db metadata into instance
+		respEvent := transistor.NewEvent(e.Name, transistor.GetAction("status"), nil)
+		respEvent.State = transistor.GetState("complete")
+
+		respEvent.AddArtifact("DB_USER", dbMetadata.Credentials.Username, false)
+		respEvent.AddArtifact("DB_PASSWORD", dbMetadata.Credentials.Password, false)
+		respEvent.AddArtifact("DB_NAME", dbMetadata.Name, false)
+		respEvent.AddArtifact("DB_ENDPOINT", (*dbInstance).GetInstanceMetadata().Endpoint, false)
+		respEvent.AddArtifact("DB_PORT", (*dbInstance).GetInstanceMetadata().Port, false)
+
+		x.events <- respEvent
+	case transistor.GetAction("delete"):
+		dbName, err := e.GetArtifact("DB_NAME")
+		if err != nil {
+			x.sendFailedStatusEvent(err)
+			return nil
+		}
+
+		dbUser, err := e.GetArtifact("DB_USER")
+		if err != nil {
+			x.sendFailedStatusEvent(err)
+			return nil
+		}
+
+		if err = (*dbInstance).DeleteDatabaseAndUser(dbName.String(), dbUser.String()); err != nil {
+			x.sendFailedStatusEvent(err)
+			return nil
+		}
+
+		// store db metadata into instance
+		respEvent := transistor.NewEvent(e.Name, transistor.GetAction("status"), nil)
+		respEvent.State = transistor.GetState("complete")
+
+		x.events <- respEvent
 	}
 
-	dbPassword := ""
-	dbName, err := genDBName(projectExtensionEvent)
-	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
-	}
-
-	dbMetadata, err := (*dbInstance).CreateDatabase(*dbName, *dbUsername, dbPassword)
-	if err != nil {
-		x.events <- getFailedStatusEvent(err)
-		return err
-	}
-
-	// store db metadata into instance
-	respEvent := transistor.NewEvent(e.Name, transistor.GetAction("status"), nil)
-	respEvent.State = transistor.GetState("complete")
-
-	respEvent.AddArtifact("DB_USER", dbMetadata.Credentials.Username, false)
-	respEvent.AddArtifact("DB_PASSWORD", dbMetadata.Credentials.Password, false)
-	respEvent.AddArtifact("DB_NAME", dbMetadata.Name, false)
-	respEvent.AddArtifact("DB_ENDPOINT", (*dbInstance).GetInstanceMetadata().Endpoint, false)
-	respEvent.AddArtifact("DB_PORT", (*dbInstance).GetInstanceMetadata().Port, false)
-
-	x.events <- respEvent
 	return nil
 }

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -1,0 +1,166 @@
+package database
+
+import (
+	"errors"
+
+	"github.com/codeamp/circuit/plugins"
+	log "github.com/codeamp/logger"
+	"github.com/codeamp/transistor"
+)
+
+// Database
+type Database struct {
+	events chan transistor.Event
+}
+
+// init
+func init() {
+	transistor.RegisterPlugin("database", func() transistor.Plugin {
+		return &Database{}
+	}, plugins.ProjectExtension{})
+}
+
+// Description
+func (x *Database) Description() string {
+	return ""
+}
+
+// SampleConfig
+func (x *Database) SampleConfig() string {
+	return ` `
+}
+
+// Start
+func (x *Database) Start(e chan transistor.Event) error {
+	x.events = e
+	log.Info("Started Database")
+	return nil
+}
+
+// Stop
+func (x *Database) Stop() {
+	log.Info("Stopping Database")
+}
+
+// Subscribe
+func (x *Database) Subscribe() []string {
+	return []string{
+		"project:database",
+	}
+}
+
+func getFailedStatusEvent(err error) transistor.Event {
+	ev := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), nil)
+	ev.State = transistor.GetState("failed")
+	ev.StateMessage = err.Error()
+	return ev
+}
+
+// Process
+func (x *Database) Process(e transistor.Event) error {
+	log.Debug("Processing database event")
+
+	// confirm all required structured inputs (Project slug, Environment)
+	if e.PayloadModel != "plugins.ProjectExtension" {
+		err := errors.New("invalid payload model")
+		log.Error(err.Error())
+		x.events <- getFailedStatusEvent(err)
+		return err
+	}
+
+	projectExtensionEvent := e.Payload.(plugins.ProjectExtension)
+
+	// Create DB within shared instance of the correct db variant (postgres/mysql)
+	instanceEndpoint, err := e.GetArtifact("SHARED_DATABASE_ENDPOINT")
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	instanceUsername, err := e.GetArtifact("SHARED_DATABASE_ADMIN_USERNAME")
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	instancePassword, err := e.GetArtifact("SHARED_DATABASE_ADMIN_PASSWORD")
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	instancePort, err := e.GetArtifact("SHARED_DATABASE_ADMIN_PORT")
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	psql := Postgres{
+		Endpoint: instanceEndpoint.String(),
+		Username: instanceUsername.String(),
+		Password: instancePassword.String(),
+		Port:     instancePort.String(),
+	}
+
+	dbName, err := genDBName(&projectExtensionEvent)
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	dbUser, err := genDBUser(&projectExtensionEvent)
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	dbInfo, err := psql.CreateDatabase(*dbName, *dbUser)
+	if err != nil {
+		x.events <- getFailedStatusEvent(err)
+	}
+
+	ev := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), nil)
+	ev.State = transistor.GetState("complete")
+	ev.AddArtifact("DB_USER", dbInfo.Username, false)
+	ev.AddArtifact("DB_PASS", dbInfo.Password, false)
+	ev.AddArtifact("DB_ENDPOINT", dbInfo.Endpoint, false)
+	ev.AddArtifact("DB_NAME", dbInfo.DBName, false)
+
+	x.events <- ev
+
+	return nil
+}
+
+func genDBName(pe *plugins.ProjectExtension) (*string, error) {
+	return nil, nil
+}
+
+func genDBUser(pe *plugins.ProjectExtension) (*string, error) {
+	return nil, nil
+}
+
+// DBInfo for the databases within the instance itself
+type DBInfo struct {
+	Username string
+	Password string
+	Endpoint string
+	DBName   string
+}
+
+// Databaser interface
+type Databaser interface {
+	CreateDatabase(string, string) (DBInfo, error)
+	DeleteDatabase(string) error
+}
+
+// Postgres
+type Postgres struct {
+	Endpoint string
+	Username string
+	Password string
+	Port     string
+}
+
+// CreateDatabase
+func (p *Postgres) CreateDatabase(dbName string, user string) (*DBInfo, error) {
+	return nil, nil
+}
+
+// DeleteDatabase
+func (p *Postgres) DeleteDatabase(dbName string) error {
+	return nil
+}

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -74,21 +74,25 @@ func (x *Database) Process(e transistor.Event) error {
 	instanceEndpoint, err := e.GetArtifact("SHARED_DATABASE_ENDPOINT")
 	if err != nil {
 		x.events <- getFailedStatusEvent(err)
+		return err
 	}
 
 	instanceUsername, err := e.GetArtifact("SHARED_DATABASE_ADMIN_USERNAME")
 	if err != nil {
 		x.events <- getFailedStatusEvent(err)
+		return err
 	}
 
 	instancePassword, err := e.GetArtifact("SHARED_DATABASE_ADMIN_PASSWORD")
 	if err != nil {
 		x.events <- getFailedStatusEvent(err)
+		return err
 	}
 
-	instancePort, err := e.GetArtifact("SHARED_DATABASE_ADMIN_PORT")
+	instancePort, err := e.GetArtifact("SHARED_DATABASE_PORT")
 	if err != nil {
 		x.events <- getFailedStatusEvent(err)
+		return err
 	}
 
 	psql := Postgres{
@@ -126,11 +130,13 @@ func (x *Database) Process(e transistor.Event) error {
 }
 
 func genDBName(pe *plugins.ProjectExtension) (*string, error) {
-	return nil, nil
+	dbName := "db"
+	return &dbName, nil
 }
 
 func genDBUser(pe *plugins.ProjectExtension) (*string, error) {
-	return nil, nil
+	user := "user"
+	return &user, nil
 }
 
 // DBInfo for the databases within the instance itself
@@ -157,7 +163,12 @@ type Postgres struct {
 
 // CreateDatabase
 func (p *Postgres) CreateDatabase(dbName string, user string) (*DBInfo, error) {
-	return nil, nil
+	return &DBInfo{
+		Endpoint: "",
+		Username: "",
+		Password: "",
+		DBName:   "",
+	}, nil
 }
 
 // DeleteDatabase

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -1,0 +1,45 @@
+package database_test
+
+import (
+	"testing"
+
+	"github.com/codeamp/circuit/test"
+	"github.com/codeamp/transistor"
+	"github.com/stretchr/testify/suite"
+)
+
+/*
+	test cases:
+	- missing pre-req inputs
+	- missing inputs
+	- api error when creating db on shared Amazon RDS instance
+	- success test case
+*/
+
+type DatabaseTestSuite struct {
+	suite.Suite
+	transistor *transistor.Transistor
+}
+
+var viperConfig = []byte(`
+plugins:
+  database:
+    workers: 1
+`)
+
+func (suite *DatabaseTestSuite) SetupSuite() {
+	suite.transistor, _ = test.SetupPluginTest(viperConfig)
+	go suite.transistor.Run()
+}
+
+func (suite *DatabaseTestSuite) TearDownSuite() {
+	suite.transistor.Stop()
+}
+
+func (suite *DatabaseTestSuite) TestDatabase_Success() {
+	return
+}
+
+func TestDatabase(t *testing.T) {
+	suite.Run(t, new(DatabaseTestSuite))
+}

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -3,8 +3,10 @@ package database_test
 import (
 	"testing"
 
+	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -34,6 +36,90 @@ func (suite *DatabaseTestSuite) SetupSuite() {
 
 func (suite *DatabaseTestSuite) TearDownSuite() {
 	suite.transistor.Stop()
+}
+
+func (suite *DatabaseTestSuite) TestDatabase_FailMissingPreRequisiteInputs() {
+	// attempt install of database extension with option 'postgres'
+	// and omit required pre-req input SHARED_DATABASE_ENDPOINT
+	databasePayload := plugins.ProjectExtension{
+		Project: plugins.Project{
+			Slug:       "checkr-deploy-test",
+			Repository: "TestDatabase_FailMissingPreRequisiteInputs",
+		},
+		Environment: "foo-env",
+	}
+	ev := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("create"), databasePayload)
+
+	ev.AddArtifact("SHARED_DATABASE_ADMIN_PASSWORD", "password", true)
+	ev.AddArtifact("SHARED_DATABASE_ADMIN_USERNAME", "username", true)
+	ev.AddArtifact("SHARED_DATABASE_PORT", "5432", true)
+
+	suite.transistor.Events <- ev
+
+	e, err := suite.transistor.GetTestEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), 10)
+	if err != nil {
+		assert.Nil(suite.T(), err)
+	}
+
+	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), transistor.GetState("failed"), e.State)
+	assert.NotNil(suite.T(), e.StateMessage)
+}
+
+func (suite *DatabaseTestSuite) TestDatabase_FailMissingInputs() {
+	// attempt install of database extension with option 'postgres'
+	// and omit required input environment
+	databasePayload := plugins.ProjectExtension{
+		Project: plugins.Project{
+			Slug:       "checkr-deploy-test",
+			Repository: "TestDatabase_FailMissingInputs",
+		},
+	}
+	ev := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("create"), databasePayload)
+
+	ev.AddArtifact("SHARED_DATABASE_ENDPOINT", "https://database-endpoint.com/create", true)
+	ev.AddArtifact("SHARED_DATABASE_ADMIN_PASSWORD", "password", true)
+	ev.AddArtifact("SHARED_DATABASE_ADMIN_USERNAME", "username", true)
+	ev.AddArtifact("SHARED_DATABASE_PORT", "5432", true)
+
+	suite.transistor.Events <- ev
+
+	e, err := suite.transistor.GetTestEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), 10)
+	if err != nil {
+		assert.Nil(suite.T(), err)
+	}
+
+	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), transistor.GetState("failed"), e.State)
+	assert.NotNil(suite.T(), e.StateMessage)
+}
+
+func (suite *DatabaseTestSuite) TestDatabase_FailExternalAPIError() {
+	// attempt install of database extension with option 'postgres'
+	// and mock failed API error
+	databasePayload := plugins.ProjectExtension{
+		Project: plugins.Project{
+			Slug:       "checkr-deploy-test",
+			Repository: "TestDatabase_FailExternalAPIError",
+		},
+		Environment: "foo-env",
+	}
+	ev := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("create"), databasePayload)
+
+	ev.AddArtifact("SHARED_DATABASE_ENDPOINT", "https://database-endpoint.com/create", true)
+	ev.AddArtifact("SHARED_DATABASE_ADMIN_PASSWORD", "password", true)
+	ev.AddArtifact("SHARED_DATABASE_ADMIN_USERNAME", "username", true)
+	ev.AddArtifact("SHARED_DATABASE_PORT", "5432", true)
+
+	suite.transistor.Events <- ev
+
+	e, err := suite.transistor.GetTestEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), 10)
+	if err != nil {
+		assert.Nil(suite.T(), err)
+	}
+
+	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
+	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 }
 
 func (suite *DatabaseTestSuite) TestDatabase_Success() {

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -63,7 +63,7 @@ func (suite *DatabaseTestSuite) TestDatabase_Success() {
 
 	suite.transistor.Events <- dbProjectExtensionEvent
 
-	e, err := suite.transistor.GetTestEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), 60)
+	_, err := suite.transistor.GetTestEvent(plugins.GetEventName("project:database"), transistor.GetAction("status"), 60)
 	if err != nil {
 		assert.FailNow(suite.T(), err.Error())
 	}

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -43,7 +43,7 @@ func (suite *DatabaseTestSuite) TestDatabase_Success() {
 	log.Println("TestDatabase_Success")
 
 	// inputs
-	dbInstanceHost := "0.0.0.0"
+	dbInstanceHost := "postgres"
 	dbAdminUsername := "postgres"
 	dbAdminPassword := ""
 	dbInstancePort := "5432"

--- a/plugins/database/errors.go
+++ b/plugins/database/errors.go
@@ -1,0 +1,6 @@
+package database
+
+const (
+	NilDBInstanceErr     = "The required instance object is nil for the %s instance object"
+	UnsupportedDBTypeErr = "Unsupported db type: %s"
+)

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -2,18 +2,34 @@ package database
 
 import (
 	"fmt"
+	"math/rand"
+	"time"
 
 	"github.com/codeamp/circuit/plugins"
 )
 
-func genDBName(pe plugins.ProjectExtension) (*string, error) {
-	dbName := "db"
-	return &dbName, nil
+// genDBName creates a database name for the specified
+// project extension with the format <project.slug>-<environment>
+func genDBName(pe plugins.ProjectExtension) string {
+	return fmt.Sprintf("%s_%s", pe.Project.Slug, pe.Environment)
 }
 
-func genDBUser(pe plugins.ProjectExtension) (*string, error) {
-	user := "user"
-	return &user, nil
+// genDBUsername creates a database username for the specified
+// project extension with the format <project.slug>-<environment>
+func genDBUser(pe plugins.ProjectExtension) string {
+	return fmt.Sprintf("%s_%s_user", pe.Project.Slug, pe.Environment)
+}
+
+func genDBPassword() string {
+	var characters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+	rand.Seed(time.Now().UnixNano())
+
+	b := make([]rune, DB_PASSWORD_LENGTH)
+	for i := range b {
+		b[i] = characters[rand.Intn(len(characters))]
+	}
+	return string(b)
 }
 
 // initDBInstance finds the correct db instance type to initialize

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -1,0 +1,13 @@
+package database
+
+import "github.com/codeamp/circuit/plugins"
+
+func genDBName(pe plugins.ProjectExtension) (*string, error) {
+	dbName := "db"
+	return &dbName, nil
+}
+
+func genDBUser(pe plugins.ProjectExtension) (*string, error) {
+	user := "user"
+	return &user, nil
+}

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -1,6 +1,10 @@
 package database
 
-import "github.com/codeamp/circuit/plugins"
+import (
+	"fmt"
+
+	"github.com/codeamp/circuit/plugins"
+)
 
 func genDBName(pe plugins.ProjectExtension) (*string, error) {
 	dbName := "db"
@@ -10,4 +14,18 @@ func genDBName(pe plugins.ProjectExtension) (*string, error) {
 func genDBUser(pe plugins.ProjectExtension) (*string, error) {
 	user := "user"
 	return &user, nil
+}
+
+// initDBInstance finds the correct db instance type to initialize
+// and returns a corresponding DatabaseInstance object
+func initDBInstance(dbType string, host string, username string, password string, port string) (*DatabaseInstance, error) {
+	var dbInstance DatabaseInstance
+	switch dbType {
+	case POSTGRESQL:
+		dbInstance = initPostgresInstance(host, username, password, port)
+	default:
+		return nil, fmt.Errorf(UnsupportedDBTypeErr, dbType)
+	}
+
+	return &dbInstance, nil
 }

--- a/plugins/database/interfaces.go
+++ b/plugins/database/interfaces.go
@@ -11,8 +11,8 @@ package database
 
 // DatabaseInstace interface
 type DatabaseInstance interface {
-	CreateDatabase(username string, password string, dbName string) (*DatabaseMetadata, error)
-	DeleteDatabase(string) error
+	CreateDatabaseAndUser(dbName string, username string, password string) (*DatabaseMetadata, error)
+	DeleteDatabaseAndUser(dbName string, username string) error
 	GetInstanceMetadata() InstanceMetadata
 }
 

--- a/plugins/database/interfaces.go
+++ b/plugins/database/interfaces.go
@@ -1,0 +1,35 @@
+package database
+
+// Databaser interface
+type DatabaseInstance interface {
+	CreateDatabase(string, string) (InstanceMetadata, error)
+	DeleteDatabase(string) error
+}
+
+// InstanceMetadata contains metadata about the database
+// and should be inherited by any struct implementing DatabaseInstance
+type InstanceMetadata struct {
+	ConnectionInformation
+}
+
+// ConnectionInformation contains the information
+// required for connecting to the instance
+type ConnectionInformation struct {
+	Credentials
+	Endpoint string
+	Port     string
+}
+
+// DatabaseMetadata contains the information
+// required for connecting to a specific database
+// within a database instance
+type DatabaseMetadata struct {
+	Credentials
+	Name string
+}
+
+// Credentials contains authorization information
+type Credentials struct {
+	Username string
+	Password string
+}

--- a/plugins/database/interfaces.go
+++ b/plugins/database/interfaces.go
@@ -1,5 +1,14 @@
 package database
 
+/*
+	The main variable to account for in the development of this extension
+	is the database instance type. If we all of a sudden want MySQL instead of Postgres,
+	the only behavior that should change is how the specific database is created and deleted
+	when requested. Thus, the DatabaseInstance interface is necessary, so that we can program to
+	it rather than specific database types within database.go. A higher-level constructor will be necessary
+	to interpret which database-type object (Postgres, MySQL, etc) to return back.
+*/
+
 // Databaser interface
 type DatabaseInstance interface {
 	CreateDatabase(string, string) (InstanceMetadata, error)

--- a/plugins/database/interfaces.go
+++ b/plugins/database/interfaces.go
@@ -9,16 +9,26 @@ package database
 	to interpret which database-type object (Postgres, MySQL, etc) to return back.
 */
 
-// Databaser interface
+// DatabaseInstace interface
 type DatabaseInstance interface {
-	CreateDatabase(string, string) (InstanceMetadata, error)
+	CreateDatabase(username string, password string, dbName string) (*DatabaseMetadata, error)
 	DeleteDatabase(string) error
+	GetInstanceMetadata() InstanceMetadata
 }
 
 // InstanceMetadata contains metadata about the database
 // and should be inherited by any struct implementing DatabaseInstance
 type InstanceMetadata struct {
 	ConnectionInformation
+}
+
+type BaseDatabaseInstance struct {
+	DatabaseInstance
+	instanceMetadata InstanceMetadata
+}
+
+func (b *BaseDatabaseInstance) GetInstanceMetadata() InstanceMetadata {
+	return b.instanceMetadata
 }
 
 // ConnectionInformation contains the information

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -1,13 +1,62 @@
 package database
 
+import (
+	"database/sql"
+	"fmt"
+
+	_ "github.com/lib/pq"
+)
+
 // Postgres
 type Postgres struct {
-	InstanceMetadata
+	BaseDatabaseInstance
+	db *sql.DB
+}
+
+// initPostgresInstance opens a postgresql connection to the host
+// and returns a DatabaseInstance object, holding the connection object
+func initPostgresInstance(host string, username string, password string, port string) DatabaseInstance {
+	db, _ := sql.Open("postgres", fmt.Sprintf("user=%s host=%s sslmode=%s password=%s port=%s", username, host, "disable", password, port))
+	return &Postgres{
+		BaseDatabaseInstance: BaseDatabaseInstance{
+			instanceMetadata: InstanceMetadata{
+				ConnectionInformation: ConnectionInformation{
+					Credentials: Credentials{
+						Username: username,
+						Password: password,
+					},
+					Endpoint: host,
+					Port:     port,
+				},
+			},
+		},
+		db: db,
+	}
 }
 
 // CreateDatabase
 func (p *Postgres) CreateDatabase(dbName string, username string, password string) (*DatabaseMetadata, error) {
-	//TODO: logic for actually provisioning a database within the instance
+	if p.db == nil {
+		return nil, fmt.Errorf(NilDBInstanceErr, "postgres")
+	}
+
+	// we have to use fmt.Sprintf here because of an issue with the underlying driver
+	// and properly sanitizing create database statements
+	_, err := p.db.Exec(fmt.Sprintf("CREATE DATABASE %s;", dbName))
+	if err != nil {
+		return nil, err
+	}
+
+	// create user permissions
+	_, err = p.db.Exec(fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s;", dbName, username))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = p.db.Exec("FLUSH PRIVILEGES;")
+	if err != nil {
+		return nil, err
+	}
 
 	return &DatabaseMetadata{
 		Name: dbName,
@@ -20,7 +69,16 @@ func (p *Postgres) CreateDatabase(dbName string, username string, password strin
 
 // DeleteDatabase
 func (p *Postgres) DeleteDatabase(dbName string) error {
-	//TODO: logic for removing the database from the instance
+	if p.db == nil {
+		return fmt.Errorf(NilDBInstanceErr, "postgres")
+	}
+
+	// we have to use fmt.Sprintf here because of an issue with the underlying driver
+	// and properly sanitizing create database statements
+	_, err := p.db.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName))
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -1,0 +1,25 @@
+package database
+
+// Postgres
+type Postgres struct {
+	InstanceMetadata
+}
+
+// CreateDatabase
+func (p *Postgres) CreateDatabase(dbName string, username string, password string) (*DatabaseMetadata, error) {
+
+	//TODO: logic for actually provisioning a database within the instance
+
+	return &DatabaseMetadata{
+		Name: dbName,
+		Credentials: Credentials{
+			Username: username,
+			Password: password,
+		},
+	}, nil
+}
+
+// DeleteDatabase
+func (p *Postgres) DeleteDatabase(dbName string) error {
+	return nil
+}

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
 
 // Postgres

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -7,7 +7,6 @@ type Postgres struct {
 
 // CreateDatabase
 func (p *Postgres) CreateDatabase(dbName string, username string, password string) (*DatabaseMetadata, error) {
-
 	//TODO: logic for actually provisioning a database within the instance
 
 	return &DatabaseMetadata{
@@ -21,5 +20,7 @@ func (p *Postgres) CreateDatabase(dbName string, username string, password strin
 
 // DeleteDatabase
 func (p *Postgres) DeleteDatabase(dbName string) error {
+	//TODO: logic for removing the database from the instance
+
 	return nil
 }

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -57,11 +57,6 @@ func (p *Postgres) CreateDatabaseAndUser(dbName string, username string, passwor
 		return nil, err
 	}
 
-	// _, err = p.db.Exec("FLUSH PRIVILEGES;")
-	// if err != nil {
-	// 	return nil, err
-	// }
-
 	return &DatabaseMetadata{
 		Name: dbName,
 		Credentials: Credentials{

--- a/plugins/events.go
+++ b/plugins/events.go
@@ -29,6 +29,7 @@ func GetEventName(s string) transistor.EventName {
 		"websocket",
 		"slack",
 		"slack:notify",
+		"project:database",
 	}
 
 	for _, t := range eventNames {


### PR DESCRIPTION
Addresses the need for automated database provisioning with a database plugin. Also contains support for creating and destroying PostgreSQL databases

### Database Plugin Spec
Required input artifacts:
```
SHARED_DATABASE_HOST
SHARED_DATABASE_ADMIN_USERNAME
SHARED_DATABASE_ADMIN_PASSWORD
SHARED_DATABASE_PORT
DB_TYPE
```

Outputs artifacts:
```
DB_NAME
DB_USER
DB_PASSWORD
```