### PR TITLE
Updated CircleCI: Only report test results if tokens are set

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,14 +64,18 @@ jobs:
             docker-compose run --rm circuit /bin/sh -c "(set -o pipefail && gotest -v -short -covermode=count -coverprofile=coverage.out ./... | tee go-test-output.txt)" || EXIT_CODE=$? && true
             
             # Generate Report XML
-            mkdir -p test-results/junit
-            go-junit-report < go-test-output.txt > test-results/junit/results.xml
+            if [[ -z "${CODECLIMATE_API_HOST}" ]]; then
+              mkdir -p test-results/junit
+              go-junit-report < go-test-output.txt > test-results/junit/results.xml
             
-            # Report to CodeBeat
-            codeclimate-test-reporter < coverage.out
+              # Report to CodeBeat
+              codeclimate-test-reporter < coverage.out
+            fi
 
             # Report to CodeCov
-            bash <(curl -s https://codecov.io/bash) -t ${CODECOV_IO_TOKEN}
+            if [[ -z "${CODECOV_IO_TOKEN}" ]]; then
+              bash <(curl -s https://codecov.io/bash) -t ${CODECOV_IO_TOKEN}
+            fi            
 
             exit $EXIT_CODE
       - store_test_results:


### PR DESCRIPTION
* Adds in bash conditional to only report test coverage if tokens are set.