### PR TITLE
Fix: add unique ids in postgresql database plugin and response event structure

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/codeamp/circuit/cmd"
 	_ "github.com/codeamp/circuit/plugins/codeamp"
+	_ "github.com/codeamp/circuit/plugins/database"
 	_ "github.com/codeamp/circuit/plugins/dockerbuilder"
 	_ "github.com/codeamp/circuit/plugins/githubstatus"
 	_ "github.com/codeamp/circuit/plugins/gitsync"

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -3,6 +3,8 @@ package database
 import (
 	"errors"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
@@ -98,6 +100,8 @@ func (x *Database) Process(e transistor.Event) error {
 		x.sendFailedStatusEvent(err)
 		return nil
 	}
+
+	spew.Dump(instanceEndpoint, instanceUsername, instancePassword, instancePort, dbType)
 
 	dbInstance, err := initDBInstance(dbType.String(), instanceEndpoint.String(), instanceUsername.String(), instancePassword.String(), instancePort.String())
 	if err != nil {

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"github.com/codeamp/circuit/plugins"
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
@@ -108,8 +106,6 @@ func (x *Database) Process(e transistor.Event) error {
 		x.sendFailedStatusEvent(err)
 		return nil
 	}
-
-	spew.Dump(instanceEndpoint, instanceUsername, instancePassword, instancePort, dbType)
 
 	dbInstance, err := initDBInstance(dbType.String(), instanceEndpoint.String(), instanceUsername.String(), instancePassword.String(), instancePort.String())
 	if err != nil {

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -2,6 +2,7 @@ package database
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
 
@@ -57,6 +58,13 @@ func (x *Database) sendFailedStatusEvent(err error) {
 	ev.State = transistor.GetState("failed")
 	ev.StateMessage = err.Error()
 	x.events <- ev
+}
+
+func (x *Database) sendSuccessResponse(e transistor.Event, state transistor.State, artifacts []transistor.Artifact) {
+	event := e.NewEvent(transistor.GetAction("status"), transistor.GetState("complete"), fmt.Sprintf("%s has completed successfully", e.Event()))
+	event.Artifacts = artifacts
+
+	x.events <- event
 }
 
 // Process
@@ -122,17 +130,14 @@ func (x *Database) Process(e transistor.Event) error {
 			return nil
 		}
 
-		// store db metadata into instance
-		respEvent := transistor.NewEvent(e.Name, transistor.GetAction("status"), nil)
-		respEvent.State = transistor.GetState("complete")
+		artifacts := make([]transistor.Artifact, 5)
+		artifacts[0] = transistor.Artifact{Key: "DB_USER", Value: dbMetadata.Credentials.Username, Secret: false}
+		artifacts[1] = transistor.Artifact{Key: "DB_PASSWORD", Value: dbMetadata.Credentials.Password, Secret: false}
+		artifacts[2] = transistor.Artifact{Key: "DB_NAME", Value: dbMetadata.Name, Secret: false}
+		artifacts[3] = transistor.Artifact{Key: "DB_ENDPOINT", Value: (*dbInstance).GetInstanceMetadata().Endpoint, Secret: false}
+		artifacts[4] = transistor.Artifact{Key: "DB_PORT", Value: (*dbInstance).GetInstanceMetadata().Port, Secret: false}
 
-		respEvent.AddArtifact("DB_USER", dbMetadata.Credentials.Username, false)
-		respEvent.AddArtifact("DB_PASSWORD", dbMetadata.Credentials.Password, false)
-		respEvent.AddArtifact("DB_NAME", dbMetadata.Name, false)
-		respEvent.AddArtifact("DB_ENDPOINT", (*dbInstance).GetInstanceMetadata().Endpoint, false)
-		respEvent.AddArtifact("DB_PORT", (*dbInstance).GetInstanceMetadata().Port, false)
-
-		x.events <- respEvent
+		x.sendSuccessResponse(e, transistor.GetState("complete"), artifacts)
 	case transistor.GetAction("delete"):
 		dbName, err := e.GetArtifact("DB_NAME")
 		if err != nil {
@@ -152,10 +157,8 @@ func (x *Database) Process(e transistor.Event) error {
 		}
 
 		// store db metadata into instance
-		respEvent := transistor.NewEvent(e.Name, transistor.GetAction("status"), nil)
-		respEvent.State = transistor.GetState("complete")
 
-		x.events <- respEvent
+		x.sendSuccessResponse(e, transistor.GetState("complete"), nil)
 	}
 
 	return nil

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -126,12 +126,13 @@ func (x *Database) Process(e transistor.Event) error {
 			return nil
 		}
 
-		artifacts := make([]transistor.Artifact, 5)
-		artifacts[0] = transistor.Artifact{Key: "DB_USER", Value: dbMetadata.Credentials.Username, Secret: false}
-		artifacts[1] = transistor.Artifact{Key: "DB_PASSWORD", Value: dbMetadata.Credentials.Password, Secret: false}
-		artifacts[2] = transistor.Artifact{Key: "DB_NAME", Value: dbMetadata.Name, Secret: false}
-		artifacts[3] = transistor.Artifact{Key: "DB_ENDPOINT", Value: (*dbInstance).GetInstanceMetadata().Endpoint, Secret: false}
-		artifacts[4] = transistor.Artifact{Key: "DB_PORT", Value: (*dbInstance).GetInstanceMetadata().Port, Secret: false}
+		artifacts := []transistor.Artifact{
+			transistor.Artifact{Key: "DB_USER", Value: dbMetadata.Credentials.Username, Secret: false},
+			transistor.Artifact{Key: "DB_PASSWORD", Value: dbMetadata.Credentials.Password, Secret: false},
+			transistor.Artifact{Key: "DB_NAME", Value: dbMetadata.Name, Secret: false},
+			transistor.Artifact{Key: "DB_ENDPOINT", Value: (*dbInstance).GetInstanceMetadata().Endpoint, Secret: false},
+			transistor.Artifact{Key: "DB_PORT", Value: (*dbInstance).GetInstanceMetadata().Port, Secret: false},
+		}
 
 		x.sendSuccessResponse(e, transistor.GetState("complete"), artifacts)
 	case transistor.GetAction("delete"):
@@ -151,8 +152,6 @@ func (x *Database) Process(e transistor.Event) error {
 			x.sendFailedStatusEvent(err)
 			return nil
 		}
-
-		// store db metadata into instance
 
 		x.sendSuccessResponse(e, transistor.GetState("complete"), nil)
 	}

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
+	"github.com/codeamp/circuit/plugins/database"
 	"github.com/codeamp/circuit/test"
 	"github.com/codeamp/transistor"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +48,7 @@ func (suite *DatabaseTestSuite) TestDatabase_Success() {
 	dbAdminUsername := "postgres"
 	dbAdminPassword := ""
 	dbInstancePort := "5432"
-	dbType := "postgresql"
+	dbType := database.POSTGRESQL
 
 	payload := plugins.ProjectExtension{
 		Project: plugins.Project{

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -12,14 +12,14 @@ import (
 // genDBName creates a database name for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBName(pe plugins.ProjectExtension) string {
-	projectSlugWithUnderscores := strings.ReplaceAll(pe.Project.Slug, "-", "_")
+	projectSlugWithUnderscores := strings.Replace(pe.Project.Slug, "-", "_", -1)
 	return fmt.Sprintf("%s_%s", projectSlugWithUnderscores, pe.Environment)
 }
 
 // genDBUsername creates a database username for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBUser(pe plugins.ProjectExtension) string {
-	projectSlugWithUnderscores := strings.ReplaceAll(pe.Project.Slug, "-", "_")
+	projectSlugWithUnderscores := strings.Replace(pe.Project.Slug, "-", "_", -1)
 	return fmt.Sprintf("%s_%s_user", projectSlugWithUnderscores, pe.Environment)
 }
 

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -62,9 +62,14 @@ func genDBPassword() string {
 // and returns a corresponding DatabaseInstance object
 func initDBInstance(dbType string, host string, username string, password string, port string) (*DatabaseInstance, error) {
 	var dbInstance DatabaseInstance
+	var err error
+
 	switch dbType {
 	case POSTGRESQL:
-		dbInstance = initPostgresInstance(host, username, password, port)
+		dbInstance, err = initPostgresInstance(host, username, password, port)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf(UnsupportedDBTypeErr, dbType)
 	}

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -7,20 +7,43 @@ import (
 	"time"
 
 	"github.com/codeamp/circuit/plugins"
+	uuid "github.com/satori/go.uuid"
 )
 
 // genDBName creates a database name for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBName(pe plugins.ProjectExtension) string {
 	projectSlugWithUnderscores := strings.Replace(pe.Project.Slug, "-", "_", -1)
-	return fmt.Sprintf("%s_%s", projectSlugWithUnderscores, pe.Environment)
+	envWithUnderscores := strings.Replace(pe.Environment, "-", "_", -1)
+	if len(projectSlugWithUnderscores) > 20 {
+		projectSlugWithUnderscores = projectSlugWithUnderscores[:20]
+	}
+
+	if len(envWithUnderscores) > 20 {
+		envWithUnderscores = envWithUnderscores[:20]
+	}
+
+	uniqueID := uuid.NewV4()
+
+	return fmt.Sprintf("%s_%s_%s", projectSlugWithUnderscores, envWithUnderscores, strings.Replace(uniqueID.String()[:15], "-", "_", -1))
 }
 
 // genDBUsername creates a database username for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBUser(pe plugins.ProjectExtension) string {
 	projectSlugWithUnderscores := strings.Replace(pe.Project.Slug, "-", "_", -1)
-	return fmt.Sprintf("%s_%s_user", projectSlugWithUnderscores, pe.Environment)
+	envWithUnderscores := strings.Replace(pe.Environment, "-", "_", -1)
+	if len(projectSlugWithUnderscores) > 20 {
+		projectSlugWithUnderscores = projectSlugWithUnderscores[:20]
+	}
+
+	if len(pe.Environment) > 20 {
+		envWithUnderscores = envWithUnderscores[:20]
+	}
+
+	uniqueID := uuid.NewV4()
+
+	return fmt.Sprintf("%s_%s_%s_user", projectSlugWithUnderscores, envWithUnderscores, strings.Replace(uniqueID.String()[:11], "-", "_", -1))
 }
 
 func genDBPassword() string {

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -3,6 +3,7 @@ package database
 import (
 	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/codeamp/circuit/plugins"
@@ -11,7 +12,8 @@ import (
 // genDBName creates a database name for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBName(pe plugins.ProjectExtension) string {
-	return fmt.Sprintf("%s_%s", pe.Project.Slug, pe.Environment)
+	projectSlugWithUnderscores := strings.ReplaceAll(pe.Project.Slug, "-", "_")
+	return fmt.Sprintf("%s_%s", projectSlugWithUnderscores, pe.Environment)
 }
 
 // genDBUsername creates a database username for the specified

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -19,7 +19,8 @@ func genDBName(pe plugins.ProjectExtension) string {
 // genDBUsername creates a database username for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBUser(pe plugins.ProjectExtension) string {
-	return fmt.Sprintf("%s_%s_user", pe.Project.Slug, pe.Environment)
+	projectSlugWithUnderscores := strings.ReplaceAll(pe.Project.Slug, "-", "_")
+	return fmt.Sprintf("%s_%s_user", projectSlugWithUnderscores, pe.Environment)
 }
 
 func genDBPassword() string {

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -3,6 +3,7 @@ package database
 import (
 	"fmt"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -16,6 +17,7 @@ type Postgres struct {
 // initPostgresInstance opens a postgresql connection to the host
 // and returns a DatabaseInstance object, holding the connection object
 func initPostgresInstance(host string, username string, password string, port string) DatabaseInstance {
+	spew.Dump(username, host, password, port)
 	db, _ := gorm.Open("postgres", fmt.Sprintf("user=%s host=%s sslmode=%s password=%s port=%s", username, host, "disable", password, port))
 	return &Postgres{
 		BaseDatabaseInstance: BaseDatabaseInstance{

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -49,17 +49,17 @@ func (p *Postgres) CreateDatabaseAndUser(dbName string, username string, passwor
 
 	// we have to use fmt.Sprintf here because of an issue with the underlying driver
 	// and properly sanitizing create database statements
-	if err := p.db.LogMode(true).Exec(fmt.Sprintf("CREATE DATABASE %s;", dbName)).Error; err != nil {
+	if err := p.db.Exec(fmt.Sprintf("CREATE DATABASE %s;", dbName)).Error; err != nil {
 		return nil, err
 	}
 
 	// create user
-	if err := p.db.LogMode(true).Exec(fmt.Sprintf("CREATE USER %s with PASSWORD '%s';", username, password)).Error; err != nil {
+	if err := p.db.Exec(fmt.Sprintf("CREATE USER %s with PASSWORD '%s';", username, password)).Error; err != nil {
 		return nil, err
 	}
 
 	// create user permissions
-	if err := p.db.LogMode(true).Exec(fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s;", dbName, username)).Error; err != nil {
+	if err := p.db.Exec(fmt.Sprintf("GRANT CONNECT ON DATABASE %s TO %s;", dbName, username)).Error; err != nil {
 		return nil, err
 	}
 
@@ -82,11 +82,11 @@ func (p *Postgres) DeleteDatabaseAndUser(dbName string, dbUser string) error {
 
 	// we have to use fmt.Sprintf here because of an issue with the underlying driver
 	// and properly sanitizing create database statements
-	if err := p.db.LogMode(true).Exec(fmt.Sprintf("DROP DATABASE %s;", dbName)).Error; err != nil {
+	if err := p.db.Exec(fmt.Sprintf("DROP DATABASE %s;", dbName)).Error; err != nil {
 		return err
 	}
 
-	if err := p.db.LogMode(true).Exec(fmt.Sprintf("DROP USER %s;", dbUser)).Error; err != nil {
+	if err := p.db.Exec(fmt.Sprintf("DROP USER %s;", dbUser)).Error; err != nil {
 		return err
 	}
 

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -3,7 +3,6 @@ package database
 import (
 	"fmt"
 
-	log "github.com/codeamp/logger"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -16,10 +15,10 @@ type Postgres struct {
 
 // initPostgresInstance opens a postgresql connection to the host
 // and returns a DatabaseInstance object, holding the connection object
-func initPostgresInstance(host string, username string, password string, port string) DatabaseInstance {
+func initPostgresInstance(host string, username string, password string, port string) (DatabaseInstance, error) {
 	db, err := gorm.Open("postgres", fmt.Sprintf("user=%s host=%s sslmode=%s password=%s port=%s", username, host, "disable", password, port))
 	if err != nil {
-		log.Info(err.Error())
+		return nil, err
 	}
 
 	return &Postgres{
@@ -36,7 +35,7 @@ func initPostgresInstance(host string, username string, password string, port st
 			},
 		},
 		db: db,
-	}
+	}, nil
 }
 
 // CreateDatabase creates a db within the DB instance

--- a/plugins/database/postgresql.go
+++ b/plugins/database/postgresql.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	log "github.com/codeamp/logger"
-	"github.com/davecgh/go-spew/spew"
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 )
@@ -18,7 +17,6 @@ type Postgres struct {
 // initPostgresInstance opens a postgresql connection to the host
 // and returns a DatabaseInstance object, holding the connection object
 func initPostgresInstance(host string, username string, password string, port string) DatabaseInstance {
-	spew.Dump(username, host, password, port)
 	db, err := gorm.Open("postgres", fmt.Sprintf("user=%s host=%s sslmode=%s password=%s port=%s", username, host, "disable", password, port))
 	if err != nil {
 		log.Info(err.Error())


### PR DESCRIPTION
Fixes:
- postgresql plugin to use a working format for returning artifacts
- including the database plugin inside `main.go`
- unique ids for postgres DB names and users to allow multiple db installations for one project

Future Improvements:
- better testing to cover full scope of practical failure cases (https://github.com/codeamp/circuit/issues/453)