### PR TITLE
KongIngress Cluster IP Fix

### DIFF
--- a/plugins/kubernetes/ingress_kong.go
+++ b/plugins/kubernetes/ingress_kong.go
@@ -103,10 +103,14 @@ func (x *Kubernetes) createKongIngress(e transistor.Event) error {
 	var artifacts []transistor.Artifact
 
 	if inputs.Type == "clusterip" {
-		artifacts = append(artifacts, transistor.Artifact{Key: "table_view", Value: fmt.Sprintf("%s.%s", service.Name, service.Namespace), Secret: false})
-		artifacts = append(artifacts, transistor.Artifact{Key: "cluster_dns", Value: fmt.Sprintf("%s.%s", service.Name, service.Namespace), Secret: false})
-		artifacts = append(artifacts, transistor.Artifact{Key: "cluster_ip", Value: service.Spec.ClusterIP, Secret: false})
-		artifacts = append(artifacts, transistor.Artifact{Key: "name", Value: inputs.Service.Name, Secret: false})
+		clusterDNS := fmt.Sprintf("%s.%s", service.Name, service.Namespace)
+		newArtifacts := []transistor.Artifact{
+			transistor.Artifact{Key: "table_view", Value: clusterDNS, Secret: false},
+			transistor.Artifact{Key: "cluster_dns", Value: clusterDNS, Secret: false},
+			transistor.Artifact{Key: "cluster_ip", Value: service.Spec.ClusterIP, Secret: false},
+			transistor.Artifact{Key: "name", Value: inputs.Service.Name, Secret: false}
+		}
+		artifacts = append(artifacts, newArtifacts...)
 		x.sendSuccessResponse(e, transistor.GetState("complete"), artifacts)
 		return nil
 	}

--- a/plugins/kubernetes/ingress_kong.go
+++ b/plugins/kubernetes/ingress_kong.go
@@ -102,6 +102,15 @@ func (x *Kubernetes) createKongIngress(e transistor.Event) error {
 	}
 	var artifacts []transistor.Artifact
 
+	if inputs.Type == "clusterip" {
+		artifacts = append(artifacts, transistor.Artifact{Key: "table_view", Value: fmt.Sprintf("%s.%s", service.Name, service.Namespace), Secret: false})
+		artifacts = append(artifacts, transistor.Artifact{Key: "cluster_dns", Value: fmt.Sprintf("%s.%s", service.Name, service.Namespace), Secret: false})
+		artifacts = append(artifacts, transistor.Artifact{Key: "cluster_ip", Value: service.Spec.ClusterIP, Secret: false})
+		artifacts = append(artifacts, transistor.Artifact{Key: "name", Value: inputs.Service.Name, Secret: false})
+		x.sendSuccessResponse(e, transistor.GetState("complete"), artifacts)
+		return nil
+	}
+
 	routesArtifact := ""
 	var tableView string
 	for idx, route := range inputs.UpstreamRoutes {

--- a/plugins/kubernetes/ingress_kong.go
+++ b/plugins/kubernetes/ingress_kong.go
@@ -108,7 +108,7 @@ func (x *Kubernetes) createKongIngress(e transistor.Event) error {
 			transistor.Artifact{Key: "table_view", Value: clusterDNS, Secret: false},
 			transistor.Artifact{Key: "cluster_dns", Value: clusterDNS, Secret: false},
 			transistor.Artifact{Key: "cluster_ip", Value: service.Spec.ClusterIP, Secret: false},
-			transistor.Artifact{Key: "name", Value: inputs.Service.Name, Secret: false}
+			transistor.Artifact{Key: "name", Value: inputs.Service.Name, Secret: false},
 		}
 		artifacts = append(artifacts, newArtifacts...)
 		x.sendSuccessResponse(e, transistor.GetState("complete"), artifacts)


### PR DESCRIPTION
Exit kong ingress create code early for clusterip types.

Currently the kong API code executes when creating a "clusterip" type, which should not happen. This returns a success message early, preventing this from happening.