### PR TITLE
Patch: change genDBUser func to have 14 chars

### DIFF
--- a/plugins/database/constants.go
+++ b/plugins/database/constants.go
@@ -4,4 +4,5 @@ const (
 	POSTGRESQL         = "postgresql"
 	MYSQL              = "mysql"
 	DB_PASSWORD_LENGTH = 32
+	DB_USER_LENGTH     = 14
 )

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -123,7 +123,7 @@ func (x *Database) Process(e transistor.Event) error {
 	// Create DB within shared instance of the correct db variant (postgres/mysql)
 	switch e.Action {
 	case transistor.GetAction("create"):
-		dbUsername := genDBUser(projectExtensionEvent)
+		dbUsername := genDBUser()
 		dbName := genDBName(projectExtensionEvent)
 		dbPassword, err := genDBPassword()
 		if err != nil {

--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -123,7 +123,12 @@ func (x *Database) Process(e transistor.Event) error {
 	// Create DB within shared instance of the correct db variant (postgres/mysql)
 	switch e.Action {
 	case transistor.GetAction("create"):
-		dbUsername := genDBUser()
+		dbUsername, err := genDBUser()
+		if err != nil {
+			x.sendFailedStatusEvent(err)
+			return nil
+		}
+
 		dbName := genDBName(projectExtensionEvent)
 		dbPassword, err := genDBPassword()
 		if err != nil {
@@ -131,7 +136,7 @@ func (x *Database) Process(e transistor.Event) error {
 			return nil
 		}
 
-		dbMetadata, err := (*dbInstance).CreateDatabaseAndUser(dbName, dbUsername, *dbPassword)
+		dbMetadata, err := (*dbInstance).CreateDatabaseAndUser(dbName, *dbUsername, *dbPassword)
 		if err != nil {
 			x.sendFailedStatusEvent(err)
 			return nil

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -29,10 +29,11 @@ func genDBName(pe plugins.ProjectExtension) string {
 	return fmt.Sprintf("%s_%s_%s", projectSlugWithUnderscores, envWithUnderscores, strings.Replace(uniqueID.String()[:12], "-", "_", -1))
 }
 
-// genDBUsername creates a unique user id
-func genDBUser(pe plugins.ProjectExtension) string {
+// genDBUser creates a database username for the specified
+// project extension with the format <project.slug>-<environment>
+func genDBUser() string {
 	uniqueID := uuid.NewV4()
-	return fmt.Sprintf("%s", uniqueID.String()[:10], "-", "_", -1)
+	return strings.Replace(uniqueID.String()[:14], "-", "_", -1)
 }
 
 func genDBPassword() (*string, error) {

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -32,8 +32,15 @@ func genDBName(pe plugins.ProjectExtension) string {
 // genDBUser creates a database username for the specified
 // project extension with the format <project.slug>-<environment>
 func genDBUser() string {
-	uniqueID := uuid.NewV4()
-	return strings.Replace(uniqueID.String()[:DB_USER_LENGTH], "-", "_", -1)
+	b := make([]byte, DB_USER_LENGTH)
+	_, err := rand.Read(b)
+	// Note that err == nil only if we read len(b) bytes.
+	if err != nil {
+		return nil, err
+	}
+
+	randString := base64.URLEncoding.EncodeToString(b)
+	return strings.Replace(uniqueID.String(), "-", "_", -1)
 }
 
 func genDBPassword() (*string, error) {

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -29,22 +29,10 @@ func genDBName(pe plugins.ProjectExtension) string {
 	return fmt.Sprintf("%s_%s_%s", projectSlugWithUnderscores, envWithUnderscores, strings.Replace(uniqueID.String()[:12], "-", "_", -1))
 }
 
-// genDBUsername creates a database username for the specified
-// project extension with the format <project.slug>-<environment>
+// genDBUsername creates a unique user id
 func genDBUser(pe plugins.ProjectExtension) string {
-	projectSlugWithUnderscores := strings.Replace(pe.Project.Slug, "-", "_", -1)
-	envWithUnderscores := strings.Replace(pe.Environment, "-", "_", -1)
-	if len(projectSlugWithUnderscores) > 10 {
-		projectSlugWithUnderscores = projectSlugWithUnderscores[:10]
-	}
-
-	if len(pe.Environment) > 6 {
-		envWithUnderscores = envWithUnderscores[:6]
-	}
-
 	uniqueID := uuid.NewV4()
-
-	return fmt.Sprintf("%s_%s_%s_user", projectSlugWithUnderscores, envWithUnderscores, strings.Replace(uniqueID.String()[:8], "-", "_", -1))
+	return fmt.Sprintf("%s", uniqueID.String()[:10], "-", "_", -1)
 }
 
 func genDBPassword() (*string, error) {

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -31,7 +31,7 @@ func genDBName(pe plugins.ProjectExtension) string {
 
 // genDBUser creates a database username for the specified
 // project extension with the format <project.slug>-<environment>
-func genDBUser() string {
+func genDBUser() (*string, error) {
 	b := make([]byte, DB_USER_LENGTH)
 	_, err := rand.Read(b)
 	// Note that err == nil only if we read len(b) bytes.
@@ -40,7 +40,7 @@ func genDBUser() string {
 	}
 
 	randString := base64.URLEncoding.EncodeToString(b)
-	return strings.Replace(uniqueID.String(), "-", "_", -1)
+	return &randString, nil
 }
 
 func genDBPassword() (*string, error) {
@@ -53,7 +53,7 @@ func genDBPassword() (*string, error) {
 
 	randString := base64.URLEncoding.EncodeToString(b)
 
-	return &randString, err
+	return &randString, nil
 }
 
 // initDBInstance finds the correct db instance type to initialize

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -39,7 +39,8 @@ func genDBUser() (*string, error) {
 		return nil, err
 	}
 
-	randString := base64.URLEncoding.EncodeToString(b)
+	randString := strings.Replace(strings.Replace(base64.URLEncoding.EncodeToString(b), "=", "", -1), "-", "", -1)
+	fmt.Println(randString)
 	return &randString, nil
 }
 

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -33,7 +33,7 @@ func genDBName(pe plugins.ProjectExtension) string {
 // project extension with the format <project.slug>-<environment>
 func genDBUser() string {
 	uniqueID := uuid.NewV4()
-	return strings.Replace(uniqueID.String()[:14], "-", "_", -1)
+	return strings.Replace(uniqueID.String()[:DB_USER_LENGTH], "-", "_", -1)
 }
 
 func genDBPassword() (*string, error) {


### PR DESCRIPTION
Change the genDBUser func to have 10 chars and only use the uuid chars. 

Improvement: A longer term fix is to allow variable lengths depending on the DB extension's artifact and use that as input when generating the function.