### PR TITLE
Patch: convert genDBUser and genDBPass to genRandomAlphabetStringWithLength in database plugin

### DIFF
--- a/plugins/database/database.go
+++ b/plugins/database/database.go
@@ -123,14 +123,14 @@ func (x *Database) Process(e transistor.Event) error {
 	// Create DB within shared instance of the correct db variant (postgres/mysql)
 	switch e.Action {
 	case transistor.GetAction("create"):
-		dbUsername, err := genDBUser()
+		dbUsername, err := genRandomAlphabetStringWithLength(DB_USER_LENGTH)
 		if err != nil {
 			x.sendFailedStatusEvent(err)
 			return nil
 		}
 
 		dbName := genDBName(projectExtensionEvent)
-		dbPassword, err := genDBPassword()
+		dbPassword, err := genRandomAlphabetStringWithLength(DB_PASSWORD_LENGTH)
 		if err != nil {
 			x.sendFailedStatusEvent(err)
 			return nil

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -1,7 +1,6 @@
 package database_test
 
 import (
-	"log"
 	"testing"
 
 	"github.com/codeamp/circuit/plugins"
@@ -41,8 +40,6 @@ func (suite *DatabaseTestSuite) TearDownSuite() {
 }
 
 func (suite *DatabaseTestSuite) TestPostgresqlDatabase_Success() {
-	log.Println("TestPostgresqlDatabase_Success")
-
 	// inputs
 	dbInstanceHost := "postgres"
 	dbAdminUsername := "postgres"

--- a/plugins/database/database_test.go
+++ b/plugins/database/database_test.go
@@ -91,7 +91,9 @@ func (suite *DatabaseTestSuite) TestPostgresqlDatabase_Success() {
 
 	assert.NotNil(suite.T(), dbName)
 	assert.NotNil(suite.T(), dbUser)
+	assert.Equal(suite.T(), len(dbUser.String()), database.DB_USER_LENGTH)
 	assert.NotNil(suite.T(), dbPassword)
+	assert.Equal(suite.T(), len(dbPassword.String()), database.DB_PASSWORD_LENGTH)
 
 	deleteDBEvent := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("delete"), payload)
 	deleteDBEvent.AddArtifact("SHARED_DATABASE_HOST", dbInstanceHost, false)
@@ -164,7 +166,9 @@ func (suite *DatabaseTestSuite) TestMySQLDatabase_Success() {
 
 	assert.NotNil(suite.T(), dbName)
 	assert.NotNil(suite.T(), dbUser)
+	assert.Equal(suite.T(), len(dbUser.String()), database.DB_USER_LENGTH)
 	assert.NotNil(suite.T(), dbPassword)
+	assert.Equal(suite.T(), len(dbPassword.String()), database.DB_PASSWORD_LENGTH)
 
 	deleteDBEvent := transistor.NewEvent(plugins.GetEventName("project:database"), transistor.GetAction("delete"), payload)
 	deleteDBEvent.AddArtifact("SHARED_DATABASE_HOST", dbInstanceHost, false)

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -2,6 +2,8 @@ package database
 
 import (
 	"fmt"
+	"log"
+	"regexp"
 	"strings"
 
 	"crypto/rand"
@@ -29,29 +31,24 @@ func genDBName(pe plugins.ProjectExtension) string {
 	return fmt.Sprintf("%s_%s_%s", projectSlugWithUnderscores, envWithUnderscores, strings.Replace(uniqueID.String()[:12], "-", "_", -1))
 }
 
-// genDBUser creates a database username for the specified
-// project extension with the format <project.slug>-<environment>
-func genDBUser() (*string, error) {
-	b := make([]byte, DB_USER_LENGTH)
+func genRandomAlphabetStringWithLength(length int) (*string, error) {
+	b := make([]byte, length)
 	_, err := rand.Read(b)
 	// Note that err == nil only if we read len(b) bytes.
 	if err != nil {
 		return nil, err
 	}
 
-	randString := strings.Replace(strings.Replace(base64.URLEncoding.EncodeToString(b), "=", "", -1), "-", "", -1)[:14]
-	return &randString, nil
-}
-
-func genDBPassword() (*string, error) {
-	b := make([]byte, DB_PASSWORD_LENGTH)
-	_, err := rand.Read(b)
-	// Note that err == nil only if we read len(b) bytes.
+	// Make a Regex to say we only want letters and numbers
+	reg, err := regexp.Compile("[^a-zA-Z]+")
 	if err != nil {
-		return nil, err
+		log.Fatal(err)
 	}
 
-	randString := base64.URLEncoding.EncodeToString(b)
+	randString := reg.ReplaceAllString(base64.RawStdEncoding.EncodeToString(b), "")
+	if len(randString) > length {
+		randString = randString[:length]
+	}
 
 	return &randString, nil
 }

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -39,8 +39,7 @@ func genDBUser() (*string, error) {
 		return nil, err
 	}
 
-	randString := strings.Replace(strings.Replace(base64.URLEncoding.EncodeToString(b), "=", "", -1), "-", "", -1)
-	fmt.Println(randString)
+	randString := strings.Replace(strings.Replace(base64.URLEncoding.EncodeToString(b), "=", "", -1), "-", "", -1)[:14]
 	return &randString, nil
 }
 

--- a/plugins/database/helpers.go
+++ b/plugins/database/helpers.go
@@ -45,10 +45,8 @@ func genRandomAlphabetStringWithLength(length int) (*string, error) {
 		log.Fatal(err)
 	}
 
-	randString := reg.ReplaceAllString(base64.RawStdEncoding.EncodeToString(b), "")
-	if len(randString) > length {
-		randString = randString[:length]
-	}
+	// a is an arbitrary char, no significance other than it being a placeholder
+	randString := reg.ReplaceAllString(base64.RawStdEncoding.EncodeToString(b), "a")[:length]
 
 	return &randString, nil
 }


### PR DESCRIPTION
- Convert genDBUser and genDBPass to one func
- Only include alphabet characters in user and password strings
- Guarantee lengths on the outputted generated string