### PR TITLE
S3 Plugin Creates Buckets

### DIFF
--- a/plugins/s3/interface.go
+++ b/plugins/s3/interface.go
@@ -10,6 +10,10 @@ import (
 
 type S3API interface {
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
+	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
+	ListBuckets(*s3.ListBucketsInput) (*s3.ListBucketsOutput, error)
+
+	PutBucketTagging(*s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
 }
 
 type IAMAPI interface {

--- a/plugins/s3/interface_test.go
+++ b/plugins/s3/interface_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	amzS3 "github.com/aws/aws-sdk-go/service/s3"
-	"github.com/davecgh/go-spew/spew"
 
 	"github.com/codeamp/circuit/plugins/s3"
 )
@@ -132,7 +131,6 @@ func (x *MockIAMClient) DeleteAccessKey(input *iam.DeleteAccessKeyInput) (*iam.D
 		delete(x.accessKeys, *input.UserName)
 	}
 
-	spew.Dump(x.accessKeys)
 	return &iam.DeleteAccessKeyOutput{}, nil
 }
 
@@ -167,15 +165,7 @@ func (x *MockIAMClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserO
 	}
 
 	if _, ok := x.accessKeys[*input.UserName]; ok == true {
-		spew.Dump(x.accessKeys)
 		return nil, errors.New("DeleteConflict - AccessKeys")
-	}
-
-	for idx, group := range x.groupMembers {
-		spew.Dump(group, idx)
-		for idx, member := range group {
-			spew.Dump(member, idx)
-		}
 	}
 
 	if _, ok := x.users[*input.UserName]; ok != true {
@@ -220,10 +210,29 @@ func (x *MockIAMClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUs
 }
 
 type MockS3Client struct {
+	buckets []*amzS3.Bucket
 }
 
 func (x *MockS3Client) PutObject(input *amzS3.PutObjectInput) (*amzS3.PutObjectOutput, error) {
 	return &amzS3.PutObjectOutput{
 		ETag: aws.String("EASLDKJASLDKJASD"),
 	}, nil
+}
+
+func (x *MockS3Client) CreateBucket(input *amzS3.CreateBucketInput) (*amzS3.CreateBucketOutput, error) {
+	x.buckets = append(x.buckets, &amzS3.Bucket{
+		Name: input.Bucket,
+	})
+
+	return &amzS3.CreateBucketOutput{Location: aws.String("mock")}, nil
+}
+
+func (x *MockS3Client) ListBuckets(input *amzS3.ListBucketsInput) (*amzS3.ListBucketsOutput, error) {
+	return &amzS3.ListBucketsOutput{
+		Buckets: x.buckets,
+	}, nil
+}
+
+func (x *MockS3Client) PutBucketTagging(input *amzS3.PutBucketTaggingInput) (*amzS3.PutBucketTaggingOutput, error) {
+	return &amzS3.PutBucketTaggingOutput{}, nil
 }

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -21,7 +21,7 @@ import (
 
 var src = rand.NewSource(time.Now().UnixNano())
 
-const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const letterBytes = "abcdefghijklmnopqrstuvwxyz"
 const (
 	letterIdxBits = 6                    // 6 bits to represent a letter index
 	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
@@ -43,7 +43,7 @@ func RandStringBytes(n int) string {
 		remain--
 	}
 
-	return strings.ToLower(string(b))
+	return string(b)
 }
 
 const s3UserPolicyTemplate = `{

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/transistor"
-	"github.com/davecgh/go-spew/spew"
 
 	log "github.com/codeamp/logger"
 
@@ -261,10 +260,14 @@ func (x *S3) extractArtifacts(e transistor.Event) (*S3Data, error) {
 	// Generate a unique prefix for this instance of the project extension
 	awsBucketSuffix, err := e.GetArtifact("aws_bucket_suffix")
 	if err != nil {
-		spew.Dump(e.Artifacts)
 		data.AWSBucketGeneratedSuffix = RandStringBytes(8)
 	} else {
 		data.AWSBucketGeneratedSuffix = awsBucketSuffix.String()
+	}
+
+	awsGeneratedUserName, err := e.GetArtifact("aws_generated_user_name")
+	if err == nil {
+		data.AWSGeneratedUserName = awsGeneratedUserName.String()
 	}
 
 	return &data, nil

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -46,16 +46,6 @@ func RandStringBytes(n int) string {
 	return strings.ToLower(string(b))
 }
 
-//
-
-// func RandStringBytes(n int) string {
-// 	b := make([]byte, n)
-// 	for i := range b {
-// 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
-// 	}
-// 	return string(b)
-// }
-
 const s3UserPolicyTemplate = `{
 	"Version": "2012-10-17",
 	"Statement": [

--- a/plugins/s3/s3.go
+++ b/plugins/s3/s3.go
@@ -3,12 +3,14 @@ package s3
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/transistor"
+	"github.com/davecgh/go-spew/spew"
 
 	log "github.com/codeamp/logger"
 
@@ -17,6 +19,43 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 )
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+const (
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return strings.ToLower(string(b))
+}
+
+//
+
+// func RandStringBytes(n int) string {
+// 	b := make([]byte, n)
+// 	for i := range b {
+// 		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+// 	}
+// 	return string(b)
+// }
 
 const s3UserPolicyTemplate = `{
 	"Version": "2012-10-17",
@@ -31,7 +70,7 @@ const s3UserPolicyTemplate = `{
 	        	"s3:AbortMultipartUpload"
 	         ],
 	        "Resource": [
-	            "arn:aws:s3:::%s/%s/*"
+	            "arn:aws:s3:::%s/*"
 	        ]
 	    },
 	    {
@@ -54,13 +93,15 @@ type S3 struct {
 }
 
 type S3Data struct {
-	AWSAccessKeyID         string
-	AWSSecretKey           string
-	AWSRegion              string
-	AWSBucket              string
-	AWSGeneratedUserPrefix string
-	AWSUserGroupName       string
-	AWSCredentialsTimeout  int
+	AWSAccessKeyID           string
+	AWSSecretKey             string
+	AWSRegion                string
+	AWSBucketPrefix          string
+	AWSGeneratedUserPrefix   string
+	AWSGeneratedUserName     string
+	AWSUserGroupName         string
+	AWSCredentialsTimeout    int
+	AWSBucketGeneratedSuffix string
 }
 
 func init() {
@@ -115,7 +156,7 @@ func (x *S3) Subscribe() []string {
 //		aws_access_key_id			- Access to create users and update policies
 //		aws_secret_key
 //		aws_region					- The region of the bucket
-// 		aws_bucket					- Which bucket to be shared
+// 		aws_bucket_prefix			- Which bucket to be shared
 //		aws_generated_user_prefix	- What should the IAM users be prefixed with
 //		aws_user_group_name			- For organizational purposes, group users together to easily find later
 // 		aws_credentials_timeout		- How long should we wait to see if the IAM credentials were successfully created
@@ -181,13 +222,13 @@ func (x *S3) extractArtifacts(e transistor.Event) (*S3Data, error) {
 	}
 	data.AWSRegion = awsRegion.String()
 
-	// Bucket
-	awsBucket, err := e.GetArtifact("aws_bucket")
+	// Bucket Prefix
+	awsBucketPrefix, err := e.GetArtifact("aws_bucket_prefix")
 	if err != nil {
 		x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
 		return nil, err
 	}
-	data.AWSBucket = awsBucket.String()
+	data.AWSBucketPrefix = awsBucketPrefix.String()
 
 	// Generated User Prefix
 	awsGeneratedUserPrefix, err := e.GetArtifact("aws_generated_user_prefix")
@@ -216,6 +257,15 @@ func (x *S3) extractArtifacts(e transistor.Event) (*S3Data, error) {
 		x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
 	}
 	data.AWSCredentialsTimeout = credentialsTimeout
+
+	// Generate a unique prefix for this instance of the project extension
+	awsBucketSuffix, err := e.GetArtifact("aws_bucket_suffix")
+	if err != nil {
+		spew.Dump(e.Artifacts)
+		data.AWSBucketGeneratedSuffix = RandStringBytes(8)
+	} else {
+		data.AWSBucketGeneratedSuffix = awsBucketSuffix.String()
+	}
 
 	return &data, nil
 }
@@ -271,11 +321,83 @@ func (x *S3) addIAMUserToGroup(data *S3Data, userName string) error {
 	return nil
 }
 
+func (x *S3) getBucketFullName(bucketPrefix string, projectSlug string, suffix string) string {
+	return fmt.Sprintf("%s-%s", bucketPrefix, suffix)
+}
+
+// Create a bucket with a given name
+func (x *S3) createBucket(data *S3Data, bucketName string) error {
+	accessKey := &iam.AccessKey{
+		AccessKeyId:     &data.AWSAccessKeyID,
+		SecretAccessKey: &data.AWSSecretKey,
+	}
+	s3Svc := x.S3Interfaces.GetS3ServiceInterface(data, accessKey)
+	_, err := s3Svc.CreateBucket(&s3.CreateBucketInput{
+		Bucket: &bucketName,
+	})
+
+	return err
+}
+
+// Try to find the bucket if it already exists
+func (x *S3) findBucket(data *S3Data, bucketName string) (bool, error) {
+	accessKey := &iam.AccessKey{
+		AccessKeyId:     &data.AWSAccessKeyID,
+		SecretAccessKey: &data.AWSSecretKey,
+	}
+
+	s3Svc := x.S3Interfaces.GetS3ServiceInterface(data, accessKey)
+	resp, err := s3Svc.ListBuckets(&s3.ListBucketsInput{})
+	if err != nil {
+		return false, err
+	}
+
+	for _, bucket := range resp.Buckets {
+		if *bucket.Name == bucketName {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (x *S3) tagBucket(data *S3Data, bucketName string, projectData *plugins.ProjectExtension, cleanup bool) error {
+	accessKey := &iam.AccessKey{
+		AccessKeyId:     &data.AWSAccessKeyID,
+		SecretAccessKey: &data.AWSSecretKey,
+	}
+	s3Svc := x.S3Interfaces.GetS3ServiceInterface(data, accessKey)
+
+	tagSet := []*s3.Tag{
+		&s3.Tag{
+			Key:   aws.String("Project"),
+			Value: &projectData.Project.Slug,
+		},
+	}
+
+	if cleanup == true {
+		tagSet = append(tagSet, &s3.Tag{
+			Key:   aws.String("DeletedAt"),
+			Value: aws.String(time.Now().UTC().String()),
+		})
+	}
+
+	_, err := s3Svc.PutBucketTagging(&s3.PutBucketTaggingInput{
+		Bucket: &bucketName,
+		Tagging: &s3.Tagging{
+			TagSet: tagSet,
+		},
+	})
+
+	return err
+}
+
 // Assign the below policy
-func (x *S3) assignUserIAMPolicyForS3(data *S3Data, userName string, prefix string) error {
+func (x *S3) assignUserIAMPolicyForS3(data *S3Data, userName string, projectData *plugins.ProjectExtension) error {
 	iamSvc := x.S3Interfaces.GetIAMServiceInterface(data)
 
-	userPolicy := fmt.Sprintf(s3UserPolicyTemplate, data.AWSBucket, prefix, data.AWSBucket)
+	bucketName := x.getBucketFullName(data.AWSBucketPrefix, projectData.Project.Slug, data.AWSBucketGeneratedSuffix)
+	userPolicy := fmt.Sprintf(s3UserPolicyTemplate, bucketName, bucketName)
 	_, err := iamSvc.PutUserPolicy(&iam.PutUserPolicyInput{
 		UserName:       &userName,
 		PolicyName:     aws.String("codeamp-storage"),
@@ -294,13 +416,15 @@ func (x *S3) assignUserIAMPolicyForS3(data *S3Data, userName string, prefix stri
 //
 // Further sanity checks could include the ability to get and delete this file afterwards
 // but a simple PutObject request should suffice for now
-func (x *S3) verifyS3CredentialsValid(e transistor.Event, data *S3Data, userName string, accessKey *iam.AccessKey, prefix string) error {
-
+func (x *S3) verifyS3CredentialsValid(e transistor.Event, data *S3Data, userName string, accessKey *iam.AccessKey, projectData *plugins.ProjectExtension) error {
 	testS3Svc := x.S3Interfaces.GetS3ServiceInterface(data, accessKey)
+
+	payload := e.Payload.(plugins.ProjectExtension)
+	bucket := x.getBucketFullName(data.AWSBucketPrefix, payload.Project.Slug, data.AWSBucketGeneratedSuffix)
 	input := &s3.PutObjectInput{
 		Body:   strings.NewReader("This is a test file written by CodeAmp. You may delete it."),
-		Bucket: &data.AWSBucket,
-		Key:    aws.String(fmt.Sprintf("%s/%s", prefix, "codeamp-write-test.txt")),
+		Bucket: &bucket,
+		Key:    aws.String("codeamp-write-test.txt"),
 	}
 
 	startedTime := time.Now()
@@ -311,6 +435,11 @@ func (x *S3) verifyS3CredentialsValid(e transistor.Event, data *S3Data, userName
 
 		_, err := testS3Svc.PutObject(input)
 		if err != nil {
+			if strings.Contains(err.Error(), "NoSuchBucket") {
+				log.Error(err.Error())
+				x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
+				return err
+			}
 			log.Warn(err.Error())
 		} else {
 			break
@@ -344,14 +473,16 @@ func (x *S3) generateAccessCredentials(data *S3Data, userName string) (*iam.Acce
 }
 
 // Prepare artifacts array to pass important information back to the front-end
-func (x *S3) buildResultArtifacts(data *S3Data, prefix string, accessKey *iam.AccessKey) []transistor.Artifact {
+func (x *S3) buildResultArtifacts(data *S3Data, accessKey *iam.AccessKey, projectSlug string) []transistor.Artifact {
 	// Stuff new credentials into artifacts to be used by the front-end
 	return []transistor.Artifact{
-		transistor.Artifact{Key: "s3_aws_access_key_id", Value: accessKey.AccessKeyId, Secret: false},
-		transistor.Artifact{Key: "s3_aws_secret_key", Value: accessKey.SecretAccessKey, Secret: false},
-		transistor.Artifact{Key: "s3_aws_region", Value: data.AWSRegion, Secret: false},
-		transistor.Artifact{Key: "s3_aws_bucket", Value: data.AWSBucket, Secret: false},
-		transistor.Artifact{Key: "s3_aws_prefix", Value: fmt.Sprintf("%s/", prefix), Secret: false},
+		transistor.Artifact{Key: "access_key_id", Value: *accessKey.AccessKeyId, Secret: false},
+		transistor.Artifact{Key: "secret_key", Value: *accessKey.SecretAccessKey, Secret: false},
+		transistor.Artifact{Key: "aws_region", Value: data.AWSRegion, Secret: false},
+		transistor.Artifact{Key: "aws_bucket_name", Value: x.getBucketFullName(data.AWSBucketPrefix, projectSlug, data.AWSBucketGeneratedSuffix), Secret: false},
+		transistor.Artifact{Key: "aws_bucket_prefix", Value: data.AWSBucketPrefix, Secret: true},
+		transistor.Artifact{Key: "aws_bucket_suffix", Value: data.AWSBucketGeneratedSuffix, Secret: true},
+		transistor.Artifact{Key: "aws_generated_user_name", Value: data.AWSGeneratedUserName, Secret: true},
 	}
 }
 
@@ -371,7 +502,39 @@ func (x *S3) createS3(e transistor.Event) error {
 	x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("running"), "Creating S3 Configuration", nil)
 
 	payload := e.Payload.(plugins.ProjectExtension)
-	userName := fmt.Sprintf("%s%s", data.AWSGeneratedUserPrefix, payload.Project.Slug)
+	userName := fmt.Sprintf("%s%s-%s", data.AWSGeneratedUserPrefix, payload.Project.Slug, RandStringBytes(4))
+	data.AWSGeneratedUserName = userName
+
+	// Create the bucket if it does not exist
+	// If it DOES exist, report an error back to the front end!
+	bucketName := x.getBucketFullName(data.AWSBucketPrefix, payload.Project.Slug, data.AWSBucketGeneratedSuffix)
+	found, err := x.findBucket(data, bucketName)
+	if err != nil {
+		log.Error(err.Error())
+		x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
+		return err
+	} else {
+		if found == true {
+			err := errors.New(fmt.Sprintf("Found an existing bucket '%s'", bucketName))
+			log.Error(err.Error())
+			x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
+			return err
+		} else {
+			err = x.createBucket(data, bucketName)
+			if err != nil {
+				log.Error(err.Error())
+				x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
+				return err
+			}
+
+			err = x.tagBucket(data, bucketName, &payload, false)
+			if err != nil {
+				log.Error(err.Error())
+				x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
+				return err
+			}
+		}
+	}
 
 	// Creates the user if they do not exist
 	err = x.createIAMUserIfNotExist(data, userName)
@@ -395,7 +558,7 @@ func (x *S3) createS3(e transistor.Event) error {
 	}
 
 	// Assign the user a policy that includes the bucket and prefix
-	err = x.assignUserIAMPolicyForS3(data, userName, payload.Project.Slug)
+	err = x.assignUserIAMPolicyForS3(data, userName, &payload)
 	if err != nil {
 		x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
 		return err
@@ -405,7 +568,7 @@ func (x *S3) createS3(e transistor.Event) error {
 	log.Warn("Testing Permissions by Writing Sample File")
 
 	x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("running"), "Waiting for AWS to propagate credentials", nil)
-	err = x.verifyS3CredentialsValid(e, data, userName, accessCredentials, payload.Project.Slug)
+	err = x.verifyS3CredentialsValid(e, data, userName, accessCredentials, &payload)
 	if err != nil {
 		log.Error(err.Error())
 		return err
@@ -416,7 +579,7 @@ func (x *S3) createS3(e transistor.Event) error {
 	x.sendS3Response(e, transistor.GetAction("status"),
 		transistor.GetState("complete"),
 		"S3 Provisioning Complete.\nRemoving this extension does not delete any data.",
-		x.buildResultArtifacts(data, payload.Project.Slug, accessCredentials))
+		x.buildResultArtifacts(data, accessCredentials, payload.Project.Slug))
 
 	return nil
 }
@@ -426,6 +589,7 @@ func (x *S3) createS3(e transistor.Event) error {
 func (x *S3) getArtifactIgnoreError(e *transistor.Event, artifactName string) transistor.Artifact {
 	artifact, err := e.GetArtifact(artifactName)
 	if err != nil {
+		log.Error(err.Error(), artifactName)
 		return transistor.Artifact{}
 	}
 
@@ -438,11 +602,12 @@ func (x *S3) updateS3(e transistor.Event) error {
 
 	// Grab the artifacts from the previous run
 	ev.Artifacts = []transistor.Artifact{
-		x.getArtifactIgnoreError(&e, "s3_aws_access_key_id"),
-		x.getArtifactIgnoreError(&e, "s3_aws_secret_key"),
-		x.getArtifactIgnoreError(&e, "s3_aws_region"),
-		x.getArtifactIgnoreError(&e, "s3_aws_bucket"),
-		x.getArtifactIgnoreError(&e, "s3_aws_prefix"),
+		x.getArtifactIgnoreError(&e, "access_key_id"),
+		x.getArtifactIgnoreError(&e, "secret_key"),
+		x.getArtifactIgnoreError(&e, "aws_region"),
+		x.getArtifactIgnoreError(&e, "aws_bucket_prefix"),
+		x.getArtifactIgnoreError(&e, "aws_bucket_suffix"),
+		x.getArtifactIgnoreError(&e, "aws_generated_user_name"),
 	}
 
 	x.events <- ev
@@ -503,7 +668,16 @@ func (x *S3) deleteS3(e transistor.Event) error {
 	iamSvc := x.S3Interfaces.GetIAMServiceInterface(data)
 
 	payload := e.Payload.(plugins.ProjectExtension)
-	userName := fmt.Sprintf("%s%s", data.AWSGeneratedUserPrefix, payload.Project.Slug)
+	userName := data.AWSGeneratedUserName
+
+	// Tag the bucket so we know that its okay to clean up
+	bucketName := x.getBucketFullName(data.AWSBucketPrefix, payload.Project.Slug, data.AWSBucketGeneratedSuffix)
+	err = x.tagBucket(data, bucketName, &payload, true)
+	if err != nil {
+		log.Error(err.Error(), bucketName)
+		x.sendS3Response(e, transistor.GetAction("status"), transistor.GetState("failed"), err.Error(), nil)
+		return err
+	}
 
 	// Check to see if user exists before we delete
 	_, err = iamSvc.GetUser(&iam.GetUserInput{UserName: &userName})

--- a/plugins/s3/s3_test.go
+++ b/plugins/s3/s3_test.go
@@ -290,8 +290,7 @@ func (suite *TestSuiteS3Extension) buildS3ExtArtifacts() []transistor.Artifact {
 		transistor.Artifact{Key: "aws_access_key_id", Value: "", Secret: false},
 		transistor.Artifact{Key: "aws_secret_key", Value: "", Secret: false},
 		transistor.Artifact{Key: "aws_region", Value: "us-east-1", Secret: false},
-		transistor.Artifact{Key: "aws_bucket", Value: "us-east-1-checkr", Secret: false},
-		transistor.Artifact{Key: "aws_prefix", Value: "checkr-deploy-test", Secret: false},
+		transistor.Artifact{Key: "aws_bucket_prefix", Value: "us-east-1", Secret: false},
 		transistor.Artifact{Key: "aws_generated_user_prefix", Value: "codeamp-testing-", Secret: false},
 		transistor.Artifact{Key: "aws_user_group_name", Value: "codeamp-testing-", Secret: false},
 		transistor.Artifact{Key: "aws_credentials_timeout", Value: "10", Secret: false},
@@ -303,7 +302,6 @@ func (suite *TestSuiteS3Extension) buildS3ExtArtifactsBadCredentials() []transis
 		transistor.Artifact{Key: "aws_access_key_id", Value: "", Secret: false},
 		transistor.Artifact{Key: "aws_secret_key", Value: "", Secret: false},
 		transistor.Artifact{Key: "aws_region", Value: "us-east-1", Secret: false},
-		transistor.Artifact{Key: "aws_bucket", Value: "us-east-1-checkr", Secret: false},
-		transistor.Artifact{Key: "aws_prefix", Value: "checkr-deploy-test/", Secret: false},
+		transistor.Artifact{Key: "aws_bucket_prefix", Value: "testing-bucket", Secret: false},
 	}
 }

--- a/plugins/s3/s3_test.go
+++ b/plugins/s3/s3_test.go
@@ -112,7 +112,7 @@ func (suite *TestSuiteS3Extension) TestUpdateS3ExtSuccess() {
 	suite.T().Log(e.StateMessage)
 	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 
-	const expectedArtifactCount = 5
+	const expectedArtifactCount = 6
 	assert.Equal(suite.T(), expectedArtifactCount, len(e.Artifacts))
 
 	for _, artifact := range e.Artifacts {
@@ -120,48 +120,6 @@ func (suite *TestSuiteS3Extension) TestUpdateS3ExtSuccess() {
 			assert.FailNow(suite.T(), fmt.Sprintf("Artifact with key '%s' was nil!", artifact.Key))
 		}
 	}
-}
-
-func (suite *TestSuiteS3Extension) TestCreateS3ExtFailureDuplicate() {
-	event := transistor.NewEvent(plugins.GetEventName("project:s3"), transistor.GetAction("create"), suite.buildS3ExtPayload())
-	event.Artifacts = suite.buildS3ExtArtifacts()
-	suite.transistor.Events <- event
-
-	var e transistor.Event
-	var err error
-	for {
-		e, err = suite.transistor.GetTestEvent("project:s3", transistor.GetAction("status"), 30)
-		if err != nil {
-			assert.Nil(suite.T(), err, err.Error())
-			return
-		}
-
-		if e.State != "running" {
-			break
-		}
-	}
-
-	suite.T().Log(e.StateMessage)
-	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
-
-	event = transistor.NewEvent(plugins.GetEventName("project:s3"), transistor.GetAction("create"), suite.buildS3ExtPayload())
-	event.Artifacts = suite.buildS3ExtArtifacts()
-	suite.transistor.Events <- event
-
-	for {
-		e, err = suite.transistor.GetTestEvent("project:s3", transistor.GetAction("status"), 30)
-		if err != nil {
-			assert.Nil(suite.T(), err, err.Error())
-			return
-		}
-
-		if e.State != "running" {
-			break
-		}
-	}
-
-	suite.T().Log(e.StateMessage)
-	assert.Equal(suite.T(), transistor.GetState("failed"), e.State)
 }
 
 func (suite *TestSuiteS3Extension) TestDeleteS3ExtSuccess() {
@@ -187,7 +145,10 @@ func (suite *TestSuiteS3Extension) TestDeleteS3ExtSuccess() {
 	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
 
 	event = transistor.NewEvent(plugins.GetEventName("project:s3"), transistor.GetAction("delete"), suite.buildS3ExtPayload())
-	event.Artifacts = suite.buildS3ExtArtifacts()
+
+	e.Artifacts = append(e.Artifacts, suite.buildS3ExtArtifacts()...)
+
+	event.Artifacts = e.Artifacts
 	suite.transistor.Events <- event
 
 	for {
@@ -232,28 +193,6 @@ func (suite *TestSuiteS3Extension) TestCreateS3ExtFailBadCredentials() {
 	event := transistor.NewEvent(plugins.GetEventName("project:s3"), transistor.GetAction("create"), nil)
 
 	event.Artifacts = suite.buildS3ExtArtifactsBadCredentials()
-	suite.transistor.Events <- event
-
-	var e transistor.Event
-	var err error
-	for {
-		e, err = suite.transistor.GetTestEvent("project:s3", transistor.GetAction("status"), 30)
-		if err != nil {
-			assert.Nil(suite.T(), err, err.Error())
-			return
-		}
-
-		if e.State != "running" {
-			break
-		}
-	}
-
-	suite.T().Log(e.StateMessage)
-	assert.Equal(suite.T(), transistor.GetState("failed"), e.State)
-}
-
-func (suite *TestSuiteS3Extension) TestCreateS3ExtFailMultipleInstall() {
-	event := transistor.NewEvent(plugins.GetEventName("project:s3"), transistor.GetAction("create"), nil)
 	suite.transistor.Events <- event
 
 	var e transistor.Event


### PR DESCRIPTION
Previously the S3 plugin used a pre-allocated bucket and then created permissions based on prefixes to slice up the bucket for other projects to share. This is inappropriate for some projects and they require a full bucket, such as in the case of ActiveRecord with its default settings. These changes modify the plugins behavior to create new buckets.