### PR TITLE
Dave/labels in redis

### DIFF
--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -119,7 +119,7 @@ func (x *CodeAmp) initPostGres() (*gorm.DB, error) {
 	}
 
 	// DEBUG
-	//db.LogMode(false)
+	// db.LogMode(true)
 
 	x.DB = db
 	return db, nil

--- a/plugins/codeamp/codeamp.go
+++ b/plugins/codeamp/codeamp.go
@@ -119,7 +119,7 @@ func (x *CodeAmp) initPostGres() (*gorm.DB, error) {
 	}
 
 	// DEBUG
-	// db.LogMode(true)
+	db.LogMode(false)
 
 	x.DB = db
 	return db, nil

--- a/plugins/codeamp/graphql/environment_test.go
+++ b/plugins/codeamp/graphql/environment_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	log "github.com/codeamp/logger"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	graphql_resolver "github.com/codeamp/circuit/plugins/codeamp/graphql"
 	"github.com/codeamp/circuit/plugins/codeamp/model"
@@ -35,6 +36,9 @@ func (suite *EnvironmentTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db}
 	suite.helper.SetResolver(suite.Resolver, "TestEnvironment")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 /* Test successful env. creation */
@@ -268,6 +272,7 @@ func (suite *EnvironmentTestSuite) TestCreate2EnvsUpdateFirstEnvironmentIsDefaul
 }
 
 func (suite *EnvironmentTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	suite.helper.TearDownTest(suite.T())
 	suite.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/environment_test.go
+++ b/plugins/codeamp/graphql/environment_test.go
@@ -129,12 +129,6 @@ func (suite *EnvironmentTestSuite) TestEnvironmentInterface() {
 	// Environment
 	envResolver := suite.helper.CreateEnvironment(suite.T())
 
-	// NonExistant Project
-	_, err := suite.helper.CreateProjectWithRepo(suite.T(), envResolver, "https://github.com/foo/goo.git")
-	if err == nil {
-		assert.FailNow(suite.T(), err.Error())
-	}
-
 	// Project
 	projectResolver, err := suite.helper.CreateProject(suite.T(), envResolver)
 	if err != nil {

--- a/plugins/codeamp/graphql/environment_test.go
+++ b/plugins/codeamp/graphql/environment_test.go
@@ -129,6 +129,12 @@ func (suite *EnvironmentTestSuite) TestEnvironmentInterface() {
 	// Environment
 	envResolver := suite.helper.CreateEnvironment(suite.T())
 
+	// NonExistant Project
+	_, err := suite.helper.CreateProjectWithRepo(suite.T(), envResolver, "https://github.com/foo/goo.git")
+	if err == nil {
+		assert.FailNow(suite.T(), err.Error())
+	}
+
 	// Project
 	projectResolver, err := suite.helper.CreateProject(suite.T(), envResolver)
 	if err != nil {

--- a/plugins/codeamp/graphql/environment_test.go
+++ b/plugins/codeamp/graphql/environment_test.go
@@ -38,7 +38,7 @@ func (suite *EnvironmentTestSuite) SetupTest() {
 	suite.helper.SetContext(test.ResolverAuthContext())
 
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 /* Test successful env. creation */

--- a/plugins/codeamp/graphql/feature_test.go
+++ b/plugins/codeamp/graphql/feature_test.go
@@ -8,6 +8,7 @@ import (
 	graphql_resolver "github.com/codeamp/circuit/plugins/codeamp/graphql"
 	"github.com/codeamp/transistor"
 	graphql "github.com/graph-gophers/graphql-go"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	"github.com/codeamp/circuit/plugins/codeamp/model"
 	_ "github.com/codeamp/circuit/plugins/gitsync"
@@ -46,6 +47,9 @@ func (suite *FeatureTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	suite.helper.SetResolver(suite.Resolver, "TestFeature")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (suite *FeatureTestSuite) TestCreateFeature() {
@@ -165,6 +169,7 @@ func (suite *FeatureTestSuite) TestGetGitCommits() {
 }
 
 func (suite *FeatureTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	suite.helper.TearDownTest(suite.T())
 	suite.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/helpers_test.go
+++ b/plugins/codeamp/graphql/helpers_test.go
@@ -78,7 +78,7 @@ func (helper *Helper) CreateEnvironmentWithError(name string) (*EnvironmentResol
 }
 
 func (helper *Helper) CreateProject(t *testing.T, envResolver *EnvironmentResolver) (*ProjectResolver, error) {
-	projectResolver, err := helper.CreateProjectWithRepo(t, envResolver, "https://github.com/foo/goo.git")
+	projectResolver, err := helper.CreateProjectWithRepo(t, envResolver, "https://github.com/golang/example.git")
 	if err == nil {
 		projectResolver.DBProjectResolver.Environment = envResolver.DBEnvironmentResolver.Environment
 	}
@@ -422,7 +422,7 @@ func (helper *Helper) CreateServiceSpec(t *testing.T, isDefault bool) *ServiceSp
 		MemoryRequest:          "300",
 		MemoryLimit:            "400",
 		TerminationGracePeriod: "500",
-		IsDefault: isDefault,
+		IsDefault:              isDefault,
 	}
 	serviceSpecResolver, err := helper.Resolver.CreateServiceSpec(&struct{ ServiceSpec *model.ServiceSpecInput }{ServiceSpec: &serviceSpecInput})
 	if err != nil {
@@ -432,7 +432,6 @@ func (helper *Helper) CreateServiceSpec(t *testing.T, isDefault bool) *ServiceSp
 	helper.cleanupServiceSpecIDs = append(helper.cleanupServiceSpecIDs, serviceSpecResolver.DBServiceSpecResolver.ServiceSpec.Model.ID)
 	return serviceSpecResolver
 }
-
 
 func (helper *Helper) CreateService(t *testing.T,
 	projectResolver *ProjectResolver,

--- a/plugins/codeamp/graphql/paginator_test.go
+++ b/plugins/codeamp/graphql/paginator_test.go
@@ -7,6 +7,7 @@ import (
 	db_resolver "github.com/codeamp/circuit/plugins/codeamp/db"
 	graphql_resolver "github.com/codeamp/circuit/plugins/codeamp/graphql"
 	"github.com/codeamp/circuit/plugins/codeamp/model"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	"github.com/codeamp/circuit/test"
 	log "github.com/codeamp/logger"
@@ -33,6 +34,9 @@ func (ts *PaginatorTestSuite) SetupTest() {
 	ts.Resolver = &graphql_resolver.Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	ts.helper.SetResolver(ts.Resolver, "TestProject")
 	ts.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *PaginatorTestSuite) TestReleaseListPaginator() {
@@ -357,6 +361,7 @@ func (ts *PaginatorTestSuite) TestProjectListPaginatorNoInput() {
 }
 
 func (ts *PaginatorTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	ts.helper.TearDownTest(ts.T())
 	ts.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/project_mutation.go
+++ b/plugins/codeamp/graphql/project_mutation.go
@@ -65,7 +65,6 @@ func (r *ProjectResolverMutation) CreateProject(ctx context.Context, args *struc
 	if protocol == "HTTPS" && !strings.Contains(args.Project.GitUrl, "@") { // now only check for public repo
 		resp, err := http.Get(args.Project.GitUrl)
 		if err != nil || resp.StatusCode != 200 {
-			fmt.Printf("#############resp.StatusCode: %d\n", resp.StatusCode)
 			return nil, fmt.Errorf("This repository does not exist on %s. Try again with a different git url.", res["host"])
 		}
 	}

--- a/plugins/codeamp/graphql/project_mutation.go
+++ b/plugins/codeamp/graphql/project_mutation.go
@@ -65,9 +65,9 @@ func (r *ProjectResolverMutation) CreateProject(ctx context.Context, args *struc
 
 	// Check if project exists in github
 	if protocol == "HTTPS" { // now only check for public repo
-		resp, err := http.Get(fmt.Sprintf("%s/%s/%s", GITHUB_REPO_API, res["owner"], res["repo"]))
+		resp, err := http.Get(args.Project.GitUrl)
 		if err != nil || resp.StatusCode != 200 {
-			return nil, fmt.Errorf("This repository does not exist on Github. Try again with a different git url.")
+			return nil, fmt.Errorf("This repository does not exist on %s. Try again with a different git url.", res["host"])
 		}
 	}
 

--- a/plugins/codeamp/graphql/project_mutation.go
+++ b/plugins/codeamp/graphql/project_mutation.go
@@ -29,8 +29,6 @@ type ProjectResolverMutation struct {
 	DB *gorm.DB
 }
 
-const GITHUB_REPO_API string = "https://api.github.com/repos"
-
 // CreateProject Create project
 func (r *ProjectResolverMutation) CreateProject(ctx context.Context, args *struct {
 	Project *model.ProjectInput
@@ -64,9 +62,10 @@ func (r *ProjectResolverMutation) CreateProject(ctx context.Context, args *struc
 	}
 
 	// Check if project exists in github
-	if protocol == "HTTPS" { // now only check for public repo
+	if protocol == "HTTPS" && !strings.Contains(args.Project.GitUrl, "@") { // now only check for public repo
 		resp, err := http.Get(args.Project.GitUrl)
 		if err != nil || resp.StatusCode != 200 {
+			fmt.Printf("#############resp.StatusCode: %d\n", resp.StatusCode)
 			return nil, fmt.Errorf("This repository does not exist on %s. Try again with a different git url.", res["host"])
 		}
 	}

--- a/plugins/codeamp/graphql/project_mutation.go
+++ b/plugins/codeamp/graphql/project_mutation.go
@@ -65,7 +65,7 @@ func (r *ProjectResolverMutation) CreateProject(ctx context.Context, args *struc
 	if protocol == "HTTPS" && !strings.Contains(args.Project.GitUrl, "@") { // now only check for public repo
 		resp, err := http.Get(args.Project.GitUrl)
 		if err != nil || resp.StatusCode != 200 {
-			return nil, fmt.Errorf("This repository does not exist on %s. Try again with a different git url.", res["host"])
+			return nil, fmt.Errorf("This repository does not exist: %s. Try again with a different git url.", args.Project.GitUrl)
 		}
 	}
 

--- a/plugins/codeamp/graphql/project_test.go
+++ b/plugins/codeamp/graphql/project_test.go
@@ -53,9 +53,8 @@ func (suite *ProjectTestSuite) SetupTest() {
 	suite.helper.SetResolver(suite.Resolver, "TestProject")
 	suite.helper.SetContext(test.ResolverAuthContext())
 
+	// add in mock to prevent exceeding github api limit
 	httpmock.Activate()
-	defer httpmock.DeactivateAndReset()
-
 	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dp", httpmock.NewStringResponder(200, "{}"))
 	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/go", httpmock.NewStringResponder(200, "{}"))
 	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dl", httpmock.NewStringResponder(200, "{}"))
@@ -1012,9 +1011,11 @@ func (suite *ProjectTestSuite) TestGetBookmarkedAndQueryProjects() {
 }
 
 func (suite *ProjectTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	fmt.Println("TearDownTest")
 	suite.helper.TearDownTest(suite.T())
 	suite.Resolver.DB.Close()
+
 }
 
 func TestProjectTestSuite(t *testing.T) {

--- a/plugins/codeamp/graphql/project_test.go
+++ b/plugins/codeamp/graphql/project_test.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
 	graphql "github.com/graph-gophers/graphql-go"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	uuid "github.com/satori/go.uuid"
@@ -51,6 +52,14 @@ func (suite *ProjectTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	suite.helper.SetResolver(suite.Resolver, "TestProject")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dp", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/go", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dl", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (suite *ProjectTestSuite) TestProjectInterface() {

--- a/plugins/codeamp/graphql/project_test.go
+++ b/plugins/codeamp/graphql/project_test.go
@@ -53,12 +53,12 @@ func (suite *ProjectTestSuite) SetupTest() {
 	suite.helper.SetResolver(suite.Resolver, "TestProject")
 	suite.helper.SetContext(test.ResolverAuthContext())
 
-	// add in mock to prevent exceeding github api limit
+	// add http mock to prevent exceeding github api limit
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dep", httpmock.NewStringResponder(200, "{}"))
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/go", httpmock.NewStringResponder(200, "{}"))
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dl", httpmock.NewStringResponder(200, "{}"))
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/dl.git", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/go.git", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/dep.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (suite *ProjectTestSuite) TestProjectInterface() {

--- a/plugins/codeamp/graphql/project_test.go
+++ b/plugins/codeamp/graphql/project_test.go
@@ -55,7 +55,7 @@ func (suite *ProjectTestSuite) SetupTest() {
 
 	// add in mock to prevent exceeding github api limit
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dp", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dep", httpmock.NewStringResponder(200, "{}"))
 	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/go", httpmock.NewStringResponder(200, "{}"))
 	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/dl", httpmock.NewStringResponder(200, "{}"))
 	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
@@ -959,8 +959,12 @@ func (suite *ProjectTestSuite) TestGetBookmarkedAndQueryProjects() {
 
 	envResolver := suite.helper.CreateEnvironment(suite.T())
 	for _, projectName := range projectNames {
+		// 	projectResolver, err := suite.helper.CreateProjectWithRepo(suite.T(), envResolver, fmt.Sprintf("https://github.com/golang/%s.git", projectName))
+		// 	assert.Nil(suite.T(), err)
 		projectResolver, err := suite.helper.CreateProjectWithRepo(suite.T(), envResolver, fmt.Sprintf("https://github.com/golang/%s.git", projectName))
-		assert.Nil(suite.T(), err)
+		if err != nil {
+			assert.FailNow(suite.T(), err.Error())
+		}
 		suite.Resolver.BookmarkProject(test.ResolverAuthContext(), &struct{ ID graphql.ID }{projectResolver.ID()})
 	}
 

--- a/plugins/codeamp/graphql/project_test.go
+++ b/plugins/codeamp/graphql/project_test.go
@@ -158,7 +158,7 @@ func (suite *ProjectTestSuite) TestProjectInterface() {
 	_ = projectResolver.Repository()
 	_ = projectResolver.Secret()
 
-	assert.Equal(suite.T(), "https://github.com/foo/goo.git", projectResolver.GitUrl())
+	assert.Equal(suite.T(), "https://github.com/golang/example.git", projectResolver.GitUrl())
 	assert.Equal(suite.T(), "HTTPS", projectResolver.GitProtocol())
 
 	_ = projectResolver.RsaPrivateKey()
@@ -225,6 +225,16 @@ func (suite *ProjectTestSuite) TestCreateProjectSuccess() {
 	projectResolver, err := suite.helper.CreateProject(suite.T(), environmentResolver)
 	assert.Nil(suite.T(), err)
 	assert.NotNil(suite.T(), projectResolver)
+}
+
+func (suite *ProjectTestSuite) TestCreateProjectFailureNonExistant() {
+	// Environment
+	environmentResolver := suite.helper.CreateEnvironment(suite.T())
+
+	// Project
+	projectResolver, err := suite.helper.CreateProjectWithRepo(suite.T(), environmentResolver, "https://github.com/foo/goo.git")
+	assert.NotNil(suite.T(), err)
+	assert.Nil(suite.T(), projectResolver)
 }
 
 func (suite *ProjectTestSuite) TestCreateProjectFailureNoEnvironments() {
@@ -537,7 +547,7 @@ func (suite *ProjectTestSuite) TestUpdateProjectHTTPSMismatchSuccess() {
 
 	envID := string(environmentResolver.ID())
 	projectInput := model.ProjectInput{
-		GitUrl:        "git@github.com:foo/goo.git",
+		GitUrl:        "git@github.com:golang/go.git",
 		GitProtocol:   "HTTPS",
 		EnvironmentID: &envID,
 	}
@@ -562,7 +572,7 @@ func (suite *ProjectTestSuite) TestUpdateProjectHTTPSMismatchSuccess() {
 	assert.NotNil(suite.T(), updatedProjectResolver)
 
 	assert.Equal(suite.T(), updatedProjectInput.GitProtocol, updatedProjectResolver.GitProtocol())
-	assert.Equal(suite.T(), "git@github.com:foo/goo.git", updatedProjectResolver.GitUrl())
+	assert.Equal(suite.T(), "git@github.com:golang/go.git", updatedProjectResolver.GitUrl())
 }
 
 func (suite *ProjectTestSuite) TestUpdateProjectSSHSuccess() {
@@ -610,7 +620,8 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHMismatchSuccess() {
 
 	envID := string(environmentResolver.ID())
 	projectInput := model.ProjectInput{
-		GitUrl:        "git@github.com:foo/goo.git",
+		// GitUrl:        "git@github.com:foo/goo.git",
+		GitUrl:        "git@github.com:golang/example.git",
 		GitProtocol:   "HTTP",
 		EnvironmentID: &envID,
 	}
@@ -625,9 +636,10 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHMismatchSuccess() {
 	branch := "master"
 	continuousDeploy := false
 	updatedProjectInput := model.ProjectInput{
-		ID:               &projectID,
-		GitProtocol:      "HTTPS",
-		GitUrl:           "git@github.com:goo/foo.git",
+		ID:          &projectID,
+		GitProtocol: "HTTPS",
+		// GitUrl:           "git@github.com:goo/foo.git",
+		GitUrl:           "git@github.com:golang/example.git",
 		GitBranch:        &branch,
 		EnvironmentID:    &envID,
 		ContinuousDeploy: &continuousDeploy,
@@ -643,7 +655,7 @@ func (suite *ProjectTestSuite) TestUpdateProjectSSHMismatchSuccess() {
 	}
 
 	assert.Equal(suite.T(), updatedProjectInput.GitProtocol, updatedProjectResolver.GitProtocol())
-	assert.Equal(suite.T(), "https://github.com/foo/goo.git", updatedProjectResolver.GitUrl())
+	assert.Equal(suite.T(), "https://github.com/golang/example.git", updatedProjectResolver.GitUrl())
 }
 
 func (suite *ProjectTestSuite) TestUpdateProjectSSHSuccessNoEnvironment() {
@@ -935,11 +947,11 @@ func (suite *ProjectTestSuite) TestRemoveBookmarkSuccess() {
 
 func (suite *ProjectTestSuite) TestGetBookmarkedAndQueryProjects() {
 	// init 3 projects into db
-	projectNames := []string{"foo", "foobar", "boo"}
+	projectNames := []string{"dep", "go", "dl"}
 
 	envResolver := suite.helper.CreateEnvironment(suite.T())
 	for _, projectName := range projectNames {
-		projectResolver, err := suite.helper.CreateProjectWithRepo(suite.T(), envResolver, fmt.Sprintf("https://github.com/username/%s.git", projectName))
+		projectResolver, err := suite.helper.CreateProjectWithRepo(suite.T(), envResolver, fmt.Sprintf("https://github.com/golang/%s.git", projectName))
 		assert.Nil(suite.T(), err)
 		suite.Resolver.BookmarkProject(test.ResolverAuthContext(), &struct{ ID graphql.ID }{projectResolver.ID()})
 	}
@@ -962,9 +974,8 @@ func (suite *ProjectTestSuite) TestGetBookmarkedAndQueryProjects() {
 	}
 
 	assert.Equal(suite.T(), 3, len(entries))
-
-	// do a search for 'foo'
-	searchQuery := "foo"
+	// do a search for names containing 'd'
+	searchQuery := "d"
 	projectList, err = suite.Resolver.Projects(test.ResolverAuthContext(), &struct {
 		ProjectSearch *model.ProjectSearchInput
 		Params        *model.PaginatorInput
@@ -982,6 +993,10 @@ func (suite *ProjectTestSuite) TestGetBookmarkedAndQueryProjects() {
 	entries, err = projectList.Entries()
 	if err != nil {
 		log.Fatal(err.Error())
+	}
+
+	for _, entry := range entries {
+		fmt.Println(entry.Name())
 	}
 
 	assert.Equal(suite.T(), 2, len(entries))

--- a/plugins/codeamp/graphql/projectextension_test.go
+++ b/plugins/codeamp/graphql/projectextension_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/codeamp/circuit/plugins/codeamp/graphql"
 	"github.com/codeamp/transistor"
 	uuid "github.com/satori/go.uuid"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	"github.com/codeamp/circuit/plugins/codeamp/model"
 	"github.com/codeamp/circuit/test"
@@ -44,6 +45,9 @@ func (suite *ProjectExtensionTestSuite) SetupTest() {
 	suite.Resolver = &Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	suite.helper.SetResolver(suite.Resolver, "TestProjectExtension")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ProjectExtensionTestSuite) TestCreateProjectExtensionSuccess() {
@@ -538,6 +542,7 @@ func (ts *ProjectExtensionTestSuite) TestHandleExtensionRoute53DuplicateFailure(
 }
 
 func (ts *ProjectExtensionTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	ts.helper.TearDownTest(ts.T())
 	ts.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/projectextension_test.go
+++ b/plugins/codeamp/graphql/projectextension_test.go
@@ -47,7 +47,7 @@ func (suite *ProjectExtensionTestSuite) SetupTest() {
 	suite.helper.SetContext(test.ResolverAuthContext())
 
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ProjectExtensionTestSuite) TestCreateProjectExtensionSuccess() {

--- a/plugins/codeamp/graphql/release_test.go
+++ b/plugins/codeamp/graphql/release_test.go
@@ -82,7 +82,7 @@ func (suite *ReleaseTestSuite) SetupTest() {
 	suite.helper.SetContext(test.ResolverAuthContext())
 
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ReleaseTestSuite) TestCreateReleaseSuccess() {

--- a/plugins/codeamp/graphql/release_test.go
+++ b/plugins/codeamp/graphql/release_test.go
@@ -13,6 +13,7 @@ import (
 	log "github.com/codeamp/logger"
 	"github.com/codeamp/transistor"
 	"github.com/jinzhu/gorm/dialects/postgres"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/stretchr/testify/assert"
@@ -79,6 +80,9 @@ func (suite *ReleaseTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	suite.helper.SetResolver(suite.Resolver, "TestRelease")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ReleaseTestSuite) TestCreateReleaseSuccess() {
@@ -2008,6 +2012,7 @@ func (ts *ReleaseTestSuite) TestCreateRollbackReleaseSuccess() {
 }
 
 func (ts *ReleaseTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	ts.helper.TearDownTest(ts.T())
 	ts.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/releaseextension_test.go
+++ b/plugins/codeamp/graphql/releaseextension_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	graphql_resolver "github.com/codeamp/circuit/plugins/codeamp/graphql"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	"github.com/codeamp/circuit/plugins/codeamp/model"
 	"github.com/codeamp/circuit/test"
@@ -45,6 +46,9 @@ func (suite *ReleaseExtensionTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	suite.helper.SetResolver(suite.Resolver, "TestReleaseExtension")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ReleaseExtensionTestSuite) TestReleaseExtensionInterface() {

--- a/plugins/codeamp/graphql/secret_test.go
+++ b/plugins/codeamp/graphql/secret_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/jinzhu/gorm/dialects/postgres"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/jarcoal/httpmock.v1"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -35,6 +36,9 @@ func (suite *SecretTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db}
 	suite.helper.SetResolver(suite.Resolver, "TestSecret")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *SecretTestSuite) TestCreateSecret() {
@@ -802,6 +806,7 @@ func (ts *SecretTestSuite) TestSecretsExport_Fail_InvalidEnvironmentID() {
 }
 
 func (ts *SecretTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	ts.helper.TearDownTest(ts.T())
 	ts.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/secret_test.go
+++ b/plugins/codeamp/graphql/secret_test.go
@@ -38,7 +38,7 @@ func (suite *SecretTestSuite) SetupTest() {
 	suite.helper.SetContext(test.ResolverAuthContext())
 
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *SecretTestSuite) TestCreateSecret() {

--- a/plugins/codeamp/graphql/service_test.go
+++ b/plugins/codeamp/graphql/service_test.go
@@ -194,7 +194,7 @@ func (suite *ServiceTestSuite) SetupTest() {
 	suite.helper.SetContext(test.ResolverAuthContext())
 
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ServiceTestSuite) TestCreateServiceNoDefaultServiceSpecFailure() {

--- a/plugins/codeamp/graphql/service_test.go
+++ b/plugins/codeamp/graphql/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/codeamp/circuit/plugins"
 	graphql_resolver "github.com/codeamp/circuit/plugins/codeamp/graphql"
 	_ "github.com/satori/go.uuid"
+	"gopkg.in/jarcoal/httpmock.v1"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/codeamp/circuit/plugins/codeamp/model"
@@ -191,6 +192,9 @@ func (suite *ServiceTestSuite) SetupTest() {
 	suite.Resolver = &graphql_resolver.Resolver{DB: db, Events: make(chan transistor.Event, 10)}
 	suite.helper.SetResolver(suite.Resolver, "TestService")
 	suite.helper.SetContext(test.ResolverAuthContext())
+
+	httpmock.Activate()
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ServiceTestSuite) TestCreateServiceNoDefaultServiceSpecFailure() {
@@ -1551,6 +1555,7 @@ func (ts *ServiceTestSuite) TestExportServices_Fail_InvalidEnvironmentID() {
 }
 
 func (ts *ServiceTestSuite) TearDownTest() {
+	httpmock.DeactivateAndReset()
 	ts.helper.TearDownTest(ts.T())
 	ts.Resolver.DB.Close()
 }

--- a/plugins/codeamp/graphql/servicespec_test.go
+++ b/plugins/codeamp/graphql/servicespec_test.go
@@ -47,7 +47,7 @@ func (suite *ServiceSpecTestSuite) SetupTest() {
 	suite.helper.SetContext(test.ResolverAuthContext())
 
 	httpmock.Activate()
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://github.com/golang/example.git", httpmock.NewStringResponder(200, "{}"))
 }
 
 func (ts *ServiceSpecTestSuite) TestCreateServiceSpecSuccess() {

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -150,6 +150,9 @@ func (suite *TestSuite) TestGithubStatus() {
 	}
 	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
+
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/go", httpmock.NewStringResponder(200, "{}"))
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func TestGithubStatus(t *testing.T) {

--- a/plugins/githubstatus/githubstatus_test.go
+++ b/plugins/githubstatus/githubstatus_test.go
@@ -150,9 +150,6 @@ func (suite *TestSuite) TestGithubStatus() {
 	}
 	assert.Equal(suite.T(), transistor.GetAction("status"), e.Action)
 	assert.Equal(suite.T(), transistor.GetState("complete"), e.State)
-
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/go", httpmock.NewStringResponder(200, "{}"))
-	httpmock.RegisterResponder("GET", "https://api.github.com/repos/golang/example", httpmock.NewStringResponder(200, "{}"))
 }
 
 func TestGithubStatus(t *testing.T) {

--- a/plugins/scheduledbranchreleaser/scheduledbranchreleaser_test.go
+++ b/plugins/scheduledbranchreleaser/scheduledbranchreleaser_test.go
@@ -11,6 +11,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
+	"gopkg.in/jarcoal/httpmock.v1"
 
 	"github.com/codeamp/circuit/plugins"
 	"github.com/codeamp/circuit/test"
@@ -73,6 +74,11 @@ plugins:
 
 	suite.transistor, _ = test.SetupPluginTest(viperConfig)
 	go suite.transistor.Run()
+
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder("GET", "https://api.github.com/repos/aballman/helloworld-node", httpmock.NewStringResponder(200, "{}"))
 }
 
 func TestScheduledBranchReleaserExtension(t *testing.T) {


### PR DESCRIPTION
Try to fix #490. Changed functions signatures to pass/return two strings. Added the project name as one of the label for Redis deployment and pods.

```
dave-chen% kubectl get pods -n test --show-labels 
NAME                                              READY   STATUS    RESTARTS   AGE   LABELS
developmen-codeamp-pa-efbbde49-5998bdcc8b-wss9h   1/1     Running   0          15m   app=developmen-codeamp-pa-efbbde49,pod-template-hash=5998bdcc8b,projectName=codeamp-panel
```

```
dave-chen% kubectl get deploy -n test --show-labels 
NAME                             READY   UP-TO-DATE   AVAILABLE   AGE   LABELS
developmen-codeamp-pa-efbbde49   1/1     1            1           14m   app=developmen-codeamp-pa-efbbde49,projectName=codeamp-panel
```



