### PR TITLE
Check for Pod Restarts On Deploy

### DIFF
--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -193,6 +193,8 @@ func detectPodFailure(pod v1.Pod) (string, bool) {
 				default:
 					return fmt.Sprintf("Pod '%s' is waiting because '%s'", pod.Name, waitingReason), false
 				}
+			} else if containerStatus.RestartCount != 0 {
+				return fmt.Sprintf("Detected Pod '%s' has restarted during deployment", pod.Name), true
 			}
 		}
 	}

--- a/plugins/kubernetes/deployment.go
+++ b/plugins/kubernetes/deployment.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/go-errors/errors"
 
 	"github.com/codeamp/circuit/plugins"
@@ -184,6 +185,9 @@ func (x *Kubernetes) createNamespaceIfNotExists(namespace string, clientset kube
 func detectPodFailure(pod v1.Pod) (string, bool) {
 	if len(pod.Status.ContainerStatuses) > 0 {
 		for _, containerStatus := range pod.Status.ContainerStatuses {
+			if containerStatus.State.Terminated != nil {
+				spew.Dump(containerStatus.State.Terminated)
+			}
 			if containerStatus.State.Waiting != nil {
 				switch waitingReason := containerStatus.State.Waiting.Reason; waitingReason {
 				case "CrashLoopBackOff", "ImageInspectError", "ErrImageNeverPull", "RegistryUnavilable", "InvalidImageName":


### PR DESCRIPTION
* Pods can be "deployed" but be stuck in a crashing state.
* Specifically happens when an application has passed the pod readiness check but then fails a liveness check and is then restarted after the application is marked as ready.
* This affects the deployment process and prevents a roll back/forward to be processed until the timeout completes.